### PR TITLE
At a Glance 3

### DIFF
--- a/app/examples/FeatureSpecExamples.scala
+++ b/app/examples/FeatureSpecExamples.scala
@@ -82,17 +82,59 @@ object FeatureSpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">TVSetSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved">with</span> <span class="stType">GivenWhenThen</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "ignore(<span class=\"stLiteral\">\"User presses power button when TV is off\"</span>) { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> {
+      |  ignore(<span class="stLiteral">"User presses power button when TV is off"</span>) { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "scenario(<span class=\"stLiteral\">\"User presses power button when TV is off\"</span>) (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> {
+      |  scenario(<span class="stLiteral">"User presses power button when TV is off"</span>) (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |scenario(<span class="stLiteral">"User presses power button when TV is off"</span>, <span class="stType">SlowTest</span>) { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> {
+      |  scenario(<span class="stLiteral">"User presses power button when TV is off"</span>, <span class="stType">SlowTest</span>) {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> {
+      |  scenario(<span class="stLiteral">"User presses power button when TV is off"</span>) {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved"> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.FeatureSpec</span> <span class="stReserved"> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/FlatSpecExamples.scala
+++ b/app/examples/FlatSpecExamples.scala
@@ -50,17 +50,60 @@ object FlatSpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "ignore should <span class=\"stLiteral\">\"produce NoSuchElementException when head is invoked\"</span> in { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+      |  ignore should <span class="stLiteral">"have size 0"</span> in { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "<span class=\"stLiteral\">\"An empty Set\" should \"have size 0\"</span> in (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+      |  <span class="stLiteral">"An empty Set" should "have size 0"</span> in (pending)
+      |}""".stripMargin
+    ""
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |it should <span class="stLiteral">"have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+      |  <span class="stLiteral">"An empty Set"</span> should <span class="stLiteral">"have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+      |  <span class="stLiteral">"An empty Set" should "have size 0"</span> in {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.FlatSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/FreeSpecExamples.scala
+++ b/app/examples/FreeSpecExamples.scala
@@ -54,17 +54,59 @@ object FreeSpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "<span class=\"stLiteral\">\"should have size 0\"</span> ignore { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+      |  <span class="stLiteral">"should have size 0"</span> ignore { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "<span class=\"stLiteral\">\"should have size 0\"</span> in (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+      |  <span class="stLiteral">"should have size 0"</span> in (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |<span class="stLiteral">"should have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+      |  <span class="stLiteral">"should have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+      |  <span class="stLiteral">"should have size 0"</span> in {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.FreeSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/FunSpecExamples.scala
+++ b/app/examples/FunSpecExamples.scala
@@ -58,17 +58,60 @@ object FunSpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "ignore(<span class=\"stLiteral\">\"should have size 0\"</span>) { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+      |  ignore(<span class="stLiteral">"should have size 0"</span>) { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
+    ""
 
   val pendingTest: String =
-    "it(<span class=\"stLiteral\">\"should have size 0\"</span>) (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+      |  it(<span class="stLiteral">"should have size 0"</span>) (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |it(<span class="stLiteral">"should have size 0"</span>, <span class="stType">SlowTest</span>) { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+      |  it(<span class="stLiteral">"should have size 0"</span>, <span class="stType">SlowTest</span>) {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+      |  it(<span class="stLiteral">"should have size 0"</span>) {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.FunSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/FunSuiteExamples.scala
+++ b/app/examples/FunSuiteExamples.scala
@@ -50,17 +50,59 @@ object FunSuiteExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "ignore(<span class=\"stLiteral\">\"An empty Set should have size 0\"</span>) { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+      |  ignore(<span class="stLiteral">"An empty Set should have size 0"</span>) { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "test(<span class=\"stLiteral\">\"An empty Set should have size 0\"</span>) (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+      |  test(<span class="stLiteral">"An empty Set should have size 0"</span>) (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |test(<span class="stLiteral">"An empty Set should have size 0"</span>, <span class="stType">SlowTest</span>) { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+      |  test(<span class="stLiteral">"An empty Set should have size 0"</span>, <span class="stType">SlowTest</span>) {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+      |  test(<span class="stLiteral">"An empty Set should have size 0"</span>) {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">fixture.FunSuite</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/PropSpecExamples.scala
+++ b/app/examples/PropSpecExamples.scala
@@ -61,19 +61,75 @@ object PropSpecExamples extends StyleTraitExamples {
       |}""".stripMargin
 
   val doNotDiscover: String =
-    """<span class="stImport">import org.scalatest._</span>
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span> <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "ignore(<span class=\"stLiteral\">\"an empty Set should have size 0\"</span>) { ... }"
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  ignore(<span class="stLiteral">"an empty Set should have size 0"</span>) { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "property(<span class=\"stLiteral\">\"an empty Set should have size 0\"</span>) (pending)"
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  property(<span class="stLiteral">"an empty Set should have size 0"</span>) (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |property(<span class="stLiteral">"an empty Set should have size 0"</span>, <span class="stType">SlowTest</span>) { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  property(<span class="stLiteral">"an empty Set should have size 0"</span>, <span class="stType">SlowTest</span>) {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  property(<span class="stLiteral">"an empty Set should have size 0"</span>) {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._
+      |import prop._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.PropSpec</span> <span class="stReserved">with</span>
+      |  <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/SpecExamples.scala
+++ b/app/examples/SpecExamples.scala
@@ -58,17 +58,57 @@ object SpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "@Ignore <span class=\"stReserved\">def</span> `should have size 0` { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> {
+      |  @Ignore <span class="stReserved">def</span> `should have size 0` { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "<span class=\"stReserved\">def</span> `should have size 0` { pending }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> {
+      |  <span class="stReserved">def</span> `should have size 0` { pending }
+      |}""".stripMargin
 
   val taggingTest: String =
-    """// SlowTest is a Java annotation
-      |@SlowTest <span class="stReserved">def</span> `should have size 0` { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._
+      |import tags.Retryable</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> {
+      |  @Retryable <span class="stReserved">def</span> `should have size 0` { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> {
+      |  <span class="stReserved">def</span> `should have size 0` {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">Spec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.Spec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/examples/StyleTraitExamples.scala
+++ b/app/examples/StyleTraitExamples.scala
@@ -24,6 +24,9 @@ trait StyleTraitExamples {
   def ignoreTest: String
   def pendingTest: String
   def taggingTest: String
+  def infoTest: String
+  def fixtureNoArgTest: String
+  def fixtureOneArgTest: String
 }
 
 object StyleTraitExamples {

--- a/app/examples/WordSpecExamples.scala
+++ b/app/examples/WordSpecExamples.scala
@@ -58,17 +58,59 @@ object WordSpecExamples extends StyleTraitExamples {
   val doNotDiscover: String =
     """<span class="stImport">import org.scalatest._</span>
       |@DoNotDiscover
-      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> { ... }
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> { <span class="stBlockComment">/*code omitted*/</span> }
     """.stripMargin
 
   val ignoreTest: String =
-    "<span class=\"stLiteral\">\"have size 0\"</span> ignore { ... }"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+      |  <span class="stLiteral">"have size 0"</span> ignore { <span class="stBlockComment">/*code omitted*/</span> }
+      |}""".stripMargin
 
   val pendingTest: String =
-    "<span class=\"stLiteral\">\"have size 0\"</span> in (pending)"
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+      |  <span class="stLiteral">"have size 0"</span> in (pending)
+      |}""".stripMargin
 
   val taggingTest: String =
-    """<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
-      |<span class="stLiteral">"have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in { ... }
-      |""".stripMargin
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">object</span> <span class="stType">SlowTest</span> <span class="stReserved">extends</span> <span class="stType">Tag</span>(<span class="stLiteral">"com.mycompany.tags.SlowTest"</span>)
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+      |  <span class="stLiteral">"have size 0"</span> taggedAs(<span class="stType">SlowTest</span>) in {
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val infoTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+      |  <span class="stLiteral">"have size 0"</span> in {
+      |    info(<span class="stLiteral">"Some information."</span>)
+      |    <span class="stBlockComment">/*code omitted*/</span>
+      |  }
+      |}""".stripMargin
+
+  val fixtureNoArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
+
+  val fixtureOneArgTest: String =
+    """<span class="stImport">import org.scalatest._</span>
+      |<span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.WordSpec</span> {
+      |  <span class="stReserved">def</span> setup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">def</span> cleanup() { <span class="stBlockComment">/*code omitted*/</span> }
+      |  <span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
+      |  <span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
+      |    setup()
+      |    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
+      |  }
+      |}""".stripMargin
 }

--- a/app/views/atAGlance.scala.html
+++ b/app/views/atAGlance.scala.html
@@ -79,12 +79,12 @@ Show examples in:
 </tr>
 
 <tr>
-<td class="ataglance" colspan="2"><code>@Html(selectedStyle.ignoreTest)</code></td>
+<td class="ataglance" colspan="2"><pre>@Html(selectedStyle.ignoreTest)</pre></td>
 <td class="ataglance" colspan="2">Ignore A Test</td>
 </tr>
 
 <tr>
-<td class="ataglance" colspan="2"><code>@Html(selectedStyle.pendingTest)</code></td>
+<td class="ataglance" colspan="2"><pre>@Html(selectedStyle.pendingTest)</pre></td>
 <td class="ataglance" colspan="2">A Pending Test</td>
 </tr>
 
@@ -94,7 +94,7 @@ Show examples in:
 </tr>
 
 <tr>
-<td class="ataglance" colspan="2"><code>info(<span class="stLiteral">"This is secret info!"</span>)</code></td>
+<td class="ataglance" colspan="2"><pre>@Html(selectedStyle.infoTest)</pre></td>
 <td class="ataglance" colspan="2">Provide information.</td>
 </tr>
 
@@ -103,27 +103,12 @@ Show examples in:
 </tr>
 
 <tr>
-<td class="ataglance" colspan="2">
-<pre>
-<span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
-  setup()
-  <span class="stReserved">try</span> test() <span class="stReserved">finally</span> cleanup()
-}
-</pre>
-</td>
+<td class="ataglance" colspan="2"><pre>@Html(selectedStyle.fixtureNoArgTest)</pre></td>
 <td class="ataglance" colspan="2"><code>withFixture</code> using <code>NoArgTest</code> for style traits in <code>org.scalatest</code> package</td>
 </tr>
 
 <tr>
-<td class="ataglance" colspan="2">
-<pre>
-<span class="stReserved">type</span> FixtureParam = <span class="stType">String</span>
-<span class="stReserved">override</span> <span class="stReserved">protected</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
-    setup()
-    <span class="stReserved">try</span> test(<span class="stLiteral">"this is a fixture param"</span>) <span class="stReserved">finally</span> cleanup()
-}
-</pre>
-</td>
+<td class="ataglance" colspan="2"><pre>@Html(selectedStyle.fixtureOneArgTest)</pre></td>
 <td class="ataglance" colspan="2"><code>withFixture</code> using <code>OneArgTest</code> for style traits in <code>org.scalatest.fixture</code> package</td>
 </tr>
 


### PR DESCRIPTION
-Switched again left and right column.
-Changed all import statements in example codes to use stImport style.
-Made first part of the examples in atAGlance page works by copy-and-paste into REPL.
