### PR TITLE
User Guide Link

### DIFF
--- a/app/views/userGuide/userGuideIndex.scala.html
+++ b/app/views/userGuide/userGuideIndex.scala.html
@@ -18,7 +18,7 @@
 @import controllers.Application.majorMinorScalaVersion
 @import controllers.Application.latestVersion
 
-@userGuidePage("Getting started") {
+@userGuidePage("User Guide") {
 
 <div style="text-align: left">
 


### PR DESCRIPTION
Fixed incorrect page name in user guide index view, which cause the User Guide link from being different when selected.
