### PR TITLE
Fix a typo in the POM XML on the Maven plugin page

### DIFF
--- a/app/views/userGuide/usingTheScalatestMavenPlugin.scala.html
+++ b/app/views/userGuide/usingTheScalatestMavenPlugin.scala.html
@@ -54,7 +54,7 @@ Here's an example of how to do this in your pom.xml:
 &lt;plugin&gt;
   &lt;groupId&gt;org.scalatest&lt;/groupId&gt;
   &lt;artifactId&gt;scalatest-maven-plugin&lt;/artifactId&gt;
-  &lt;version&gt;1.0.RC2&lt;/version&gt;
+  &lt;version&gt;1.0-RC2&lt;/version&gt;
   &lt;configuration&gt;
     &lt;reportsDirectory&gt;${project.build.directory}/surefire-reports&lt;/reportsDirectory&gt;
     &lt;junitxml&gt;.&lt;/junitxml&gt;


### PR DESCRIPTION
Hi, here is a small fix on the Maven plugin page. The typo prevents users from doing a direct copy-paste of the POM XML.
