### PR TITLE
ScalaTest+Play Version 1.1.1 & 1.2.0

### DIFF
--- a/app/views/plus/playVersions.scala.html
+++ b/app/views/plus/playVersions.scala.html
@@ -47,7 +47,7 @@ Click on the <em>ScalaTest + Play</em> to visit the Scaladoc for that release.
 </tr>
 <tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="http://doc.scalatest.org/plus-play/1.0.00#package">1.0.1</a></td>
-<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.1.6</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.1.x</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.2.x</td>
 </tr>
 


### PR DESCRIPTION
Added ScalaTest+Play version 1.1.1 and 1.2.0 to Versions, Versions, Versions.
