### PR TITLE
Updated ScalaMock part of 'Testing with mock objects'

### DIFF
--- a/app/views/userGuide/testingWithMockObjects.scala.html
+++ b/app/views/userGuide/testingWithMockObjects.scala.html
@@ -45,30 +45,9 @@ Here are links to the mocking frameworks described on this page:
 <h1>Using ScalaMock</h1>
 
 <p>
-<a href="http://www.scalamock.org">ScalaMock</a> is a native, open-source Scala mocking
+<a href="http://scalamock.org">ScalaMock</a> is a native, open-source Scala mocking
     framework written by Paul Butcher that allows you to mock objects and functions.
-ScalaMock supports three different mocking styles:
 </p>
-
-<!--
-    Here's how the example used in the previous sections would look in ScalaMock:
-<pre class="stHighlighted">
-<span class="stReserved">val</span> mockCollaborator = mock[<span class="stType">Collaborator</span>]
-
-mockCollaborator expects 'documentAdded withArgs (<span class="stQuotedString">"Document"</span>)
-mockCollaborator expects 'documentChanged withArgs (<span class="stQuotedString">"Document"</span>) repeated <span class="stLiteral">3</span> times
-
-classUnderTest.addDocument(<span class="stQuotedString">"Document"</span>, <span class="stReserved">new</span> <span class="stType">Array[Byte]</span>(<span class="stLiteral">0</span>))
-classUnderTest.addDocument(<span class="stQuotedString">"Document"</span>, <span class="stReserved">new</span> <span class="stType">Array[Byte]</span>(<span class="stLiteral">0</span>))
-classUnderTest.addDocument(<span class="stQuotedString">"Document"</span>, <span class="stReserved">new</span> <span class="stType">Array[Byte]</span>(<span class="stLiteral">0</span>))
-classUnderTest.addDocument(<span class="stQuotedString">"Document"</span>, <span class="stReserved">new</span> <span class="stType">Array[Byte]</span>(<span class="stLiteral">0</span>))
-</pre>
--->
-<ul>
-<li>Function mocks</li>
-<li>Proxy (dynamic) mocks</li>
-<li>Generated (type-safe) mocks</li>
-</ul>
 
 <p>To use ScalaMock, mix <code>org.scalamock.scalatest.MockFactory</code> into your <code>Suite</code> class,
 as in:
@@ -80,7 +59,7 @@ as in:
 class <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">FlatSpec</span> <span class="stReserved">with <span class="stType">MockFactory</span> <span class="stReserved">with ...
 </pre>
 
-<h2>Function mocks</h2>
+<h2>Mocking functions</h2>
 
 <p>Function mocks are created with <code>mockFunction</code>. The following, for example, creates a mock
 function taking a single <code>Int</code> argument and returning a <code>String</code>:</p>
@@ -89,7 +68,7 @@ function taking a single <code>Int</code> argument and returning a <code>String<
 <span class="stReserved">val</span> m = mockFunction[<span class="stType">Int</span>, <span class="stType">String</span>]
 </pre>
 
-<p>You can then set expectations set on the mock function. For example, here's how you'd state that you
+<p>You can then set expectations on the mock function. For example, here's how you'd state that you
 expect your mock to be called once with the argument <code>42</code>, and that when called like that
 it should return the string <code>&quot;Forty two&quot;</code>:</p>
 
@@ -97,302 +76,137 @@ it should return the string <code>&quot;Forty two&quot;</code>:</p>
 m expects (<span class="stLiteral">42</span>) returning <span class="stQuotedString">&quot;Forty two&quot;</span> once
 </pre>
 
-<h2>Proxy mocks</h2>
+<h2>Mocking objects</h2>
 
-<p>Proxy mocks can only be used to mock Scala traits and Java interfaces. (To mock classes, singleton/companion
-objects <em>etc</em>., please use <a href="#generatedMocks">generated mocks</a>.)
-To use proxy mocks, mix <code>org.scalamock.ProxyMockFactory</code> into your test suite.
-Proxy mocks are created with <code>mock</code>. The following, for example, creates a mock that implements
+You can also mock Scala and Java classes, traits and interfaces. Object mocks are created with <code>mock</code>. The following, for example, creates a mock that implements
 all the <code>Turtle</code> trait (interface):</p>
 
 <pre class="stHighlighted">
-<span class="stReserved">val</span> m = mock[<span class="stType">Turtle</span>]
+<span class="stReserved">val</span> turtleMock = mock[<span class="stType">Turtle</span>]
 </pre>
 
 <p>You can then set expectations on each of the methods within those traits. Here's an example:</p>
 
 <pre class="stHighlighted">
-m expects 'setPosition withArgs (<span class="stLiteral">10.0</span>, <span class="stLiteral">10.0</span>)
-m expects 'forward withArgs (<span class="stLiteral">5.0</span>)
-m expects 'getPosition returning (<span class="stLiteral">15.0</span>, <span class="stLiteral">10.0</span>)
+(turtleMock.setPosition _) expects (<span class="stLiteral">10.0</span>, <span class="stLiteral">10.0</span>)
+(turtleMock.forward _) expects (<span class="stLiteral">5.0</span>)
+(turtleMock.getPosition _) expects() returning (<span class="stLiteral">15.0</span>, <span class="stLiteral">10.0</span>)
 </pre>
 
-<p>By default, an expectation accepts any arguments and a single call. The following two statements are equivalent:</p>
+<p>By default, an expectation accepts a single call. The following two statements are equivalent:</p>
 
 <pre class="stHighlighted">
-m expects 'forward withArgs (*) once
-m expects 'forward
+(turtleMock.forward_) expects (*) once
+(turtleMock.forward_) expects (*)
 </pre>
 
-<p>As a convenience, proxy mocks also support the <code>stubs</code> method. The following two statements are equivalent:</p>
+<h2>Two mocking styles </h2>
+<p>
+ScalaMock supports two different mocking styles&#8212;<em>expectations-first</em> and <em>record-then-verify</em>. These styles can be mixed within a single test.</p>
+<p>
+
+In the <em>expectations-first</em> style (which was used in previous examples), expectations are set on mock objects before exercising the system under test. If these expectations are not met, the test fails. 
+</p>
+<p>You can also use <em>record-then-verify (Mockito)</em> mocking style, where expectations are verified after the system under test has executed.</p>
+
+To use this style use <code>stub</code> instead of <code>mock</code>:
 
 <pre class="stHighlighted">
-m expects 'forward anyNumberOfTimes
-m stubs 'forward
+<span class="stReserved">val</span> heaterStub = stub[<span class="stType">Heater</span>]
 </pre>
-
-<a name="generatedMocks"></a>
-<h2>Generated mocks</h2>
-
-<p>Generated mocks rely on the ScalaMock compiler plugin.
-Classes that are going to be mocked need to be declared with the <code>org.scalamock.annotation.mock</code>
-annotation. To mock a class together with its companion object, use
-<code>org.scalamock.annotation.mockWithCompanion</code>. To mock a standalone singleton object, use
-<code>org.scalamock.annotation.mockObject</code>.</p>
-
-<p>In addition to <code>MockFactory</code>, your test class also needs to mix in <code>GeneratedMockFactory</code>.</p>
-
-<p>Then, to create a regular mock object, use <code>mock</code>:</p>
-
+<p>Return values that are used by the system under test can be set up by using <code>when</code> before running the tested system. Calls are verified using <code>verify</code>:</p>
 <pre class="stHighlighted">
-<span class="stReserved">val</span> m = mock[<span class="stType">Turtle</span>]
+<span class="stLiteral">"CoffeeMachine"</span> should <span class="stLiteral">"turn off the heater after coffee making is finished"</span> in {
+  <span class="stReserved">val</span> heaterStub = stub[<span class="stType">Heater</span>]
+  <span class="stReserved">val</span> coffeeMachine = <span class="stReserved">new</span> <span class="stType">CoffeeMachine</span>(heaterStub)
 
-m.expects.forward(<span class="stLiteral">10.0</span>) twice
-</pre>
+  (heaterStub.isReady _).when().returns(<span class="stLiteral">true</span>)
 
-<p>To mock a singleton or companion object, use <code>mockObject</code>:</p>
+  coffeeMachine.makeCoffee()
 
-<pre class="stHighlighted">
-<span class="stReserved">val</span> m = mockObject(<span class="stType">Turtle</span>)
-
-m.expects.createTurtle
-</pre>
-
-<p>And to mock a constructor invocation, use <code>newInstance</code>:</p>
-
-<pre class="stHighlighted">
-<span class="stReserved">val</span> m = mock[<span class="stType">Turtle</span>]
-
-m.expects.newInstance('blue)
-m.expects.forward(<span class="stLiteral">10.0</span>)
-</pre>
-
-<h2>Expectations</h2>
-
-<p>You can specify expectations about the arguments with which a function or method is called and
-how many times it will be called. In addition, you can instruct a mock to return a particular value or throw
-an exception when that expectation is met.</p>
-
-<h3>Arguments</h3>
-
-<p>To specify expected arguments for a functional mock, use <code>expects</code>. To specify expected
-arguments for a proxy mock, use <code>withArgs</code> or <code>withArguments</code>.</p>
-
-<p>If no expected arguments are given, mocks accept any arguments.</p>
-
-<p>To specify arguments that should simply be tested for equality, provide the expected arguments
-as a tuple:</p>
-
-<pre class="stHighlighted">
-m expects (<span class="stQuotedString">&quot;this&quot;</span>, <span class="stQuotedString">&quot;that&quot;</span>)
-</pre>
-
-<p>ScalaMock currently supports two types of generalized matching: <i>wildcards</i> and <i>epsilon
-matching</i>.</p>
-
-<h3>Wildcards</h3>
-
-<p>Wildcard values are specified with an <code>*</code> (asterisk). For example:</p>
-
-<pre class="stHighlighted">
-m expects (<span class="stQuotedString">&quot;this&quot;</span>, *)
-</pre>
-
-<p>will match any of the following:</p>
-
-<pre class="stHighlighted">
-m(<span class="stQuotedString">&quot;this&quot;</span>, <span class="stLiteral">42</span>)
-m(<span class="stQuotedString">&quot;this&quot;</span>, <span class="stLiteral">1.0</span>)
-m(<span class="stQuotedString">&quot;this&quot;</span>, <span class="stLiteral">null</span>)
-</pre>
-
-<h3>Epsilon matching</h3>
-
-<p>Epsilon matching is useful when dealing with floating point values. An epsilon match is
-specified with the <code>~</code> (tilde) operator:</p>
-
-<pre class="stHighlighted">
-m expects (~<span class="stLiteral">42.0</span>)
-</pre>
-
-<p>will match:</p>
-
-<pre class="stHighlighted">
-m(<span class="stLiteral">42.0</span>)
-m(<span class="stLiteral">42.0001</span>)
-m(<span class="stLiteral">41.9999</span>)
-</pre>
-
-<p>but will not match:</p>
-
-<pre class="stHighlighted">
-m(<span class="stLiteral">43.0</span>)
-m(<span class="stLiteral">42.1</span>)
-</pre>
-
-<h3>Repeated parameters</h3>
-
-<p>If you're using generated mocks, you need do nothing special to set expectations on methods
-that take repeated parameters. If you're using proxy mocks you will need to use
-the <code>**</code> operator. For example, given:</p>
-
-<pre class="stHighlighted">
-def takesRepeatedParameter(x: <span class="stType">Int</span>, ys: <span class="stType">String</span>*)
-</pre>
-
-<p>you can set an expectation with:</p>
-
-<pre class="stHighlighted">
-m expects 'takesRepeatedParameter withArgs(<span class="stLiteral">42</span>, **(&quot;red&quot;, &quot;green&quot;, &quot;blue&quot;))
-</pre>
-
-<h3>Predicate matching</h3>
-
-<p>More complicated argument matching can be implemented by using <code>where</code> to pass a predicate:</p>
-
-<pre class="stHighlighted">
-m = mockFunction[<span class="stType">Double</span>, <span class="stType">Double</span>, <span class="stType">Unit</span>]
-m expects { where _ &lt; _ }
-</pre>
-
-<pre class="stHighlighted">
-m = mock[<span class="stType">Turtle</span>]
-m expects 'setPosition where { (x: <span class="stType">Double</span>, y: <span class="stType">Double</span>) =&gt; x &lt; y }
-</pre>
-
-<h3>Return value</h3>
-
-<p>You can instruct a mock to return a specific value with <code>returns</code> or <code>returning</code>:</p>
-
-<pre class="stHighlighted">
-m1 returns <span class="stLiteral">42</span>
-m2 expects (<span class="stQuotedString">&quot;this&quot;</span>, <span class="stQuotedString">&quot;that&quot;</span>) returning <span class="stQuotedString">&quot;the other&quot;</span>
-</pre>
-
-<p>If no return value is specified, functional mocks return <code>null.asInstanceOf[R]</code>, where <code>R</code> is the
-return type (which equates to <code>0</code> for <code>Int</code>, <code>0.0</code> for <code>Double</code> <em>etc</em>.).</p>
-
-<p>If no return value is specified, proxy mocks return <code>null</code>. This works correctly for most return
-types, but not for methods returning primitive types (<code>Int</code>, <code>Double</code> <em>etc</em>.), where returning
-<code>null</code> leads to a <code>NullPointerException</code>. So you will need to explicitly specify a return value
-for such methods. (This restriction may be lifted in the future.)</p>
-
-<p>You can return a computed value (or throw a computed exception) with <code>onCall</code>, for example:</p>
-
-<pre class="stHighlighted">
-<span class="stReserved">val</span> mockIncrement = mockFunction[<span class="stType">Int</span>, <span class="stType">Int</span>]
-m expects (*) onCall { x: <span class="stType">Int</span> =&gt; x + <span class="stLiteral">1</span> }
-</pre>
-
-<h3>Exceptions</h3>
-
-<p>Instead of a return value, a mock can be instructed to throw:</p>
-
-<pre class="stHighlighted">
-m expects (<span class="stQuotedString">&quot;this&quot;</span>, <span class="stQuotedString">&quot;that&quot;</span>) throws new RuntimeException(<span class="stQuotedString">&quot;what's that?&quot;</span>)
-</pre>
-
-<h3>Call count</h3>
-
-<p>By default, mocks expect one or more calls (<em>i.e.</em>, only fail if the function or method is never
-called). An exact number of calls or a range can be set with <code>repeat</code>:</p>
-
-<pre class="stHighlighted">
-m1 returns <span class="stLiteral">42</span> repeat <span class="stLiteral">3</span> to <span class="stLiteral">7</span>
-m2 expects (<span class="stLiteral">3</span>) repeat <span class="stLiteral">10</span>
-</pre>
-
-<p>There are various aliases for common expectations and styles:</p>
-
-<pre class="stHighlighted">
-m1 expects (<span class="stQuotedString">&quot;this&quot;</span>, <span class="stQuotedString">&quot;that&quot;</span>) once
-m2 returns <span class="stQuotedString">&quot;foo&quot;</span> noMoreThanTwice
-m3 expects (<span class="stLiteral">42</span>) repeated <span class="stLiteral">3</span> times
-</pre>
-
-<p>For a full list, see <code>org.scalamock.Expectation</code>.</p>
-
-<h2>Ordering</h2>
-
-<p>By default, expectations can be satisfied in any order. For example:</p>
-
-<pre class="stHighlighted">
-m expects (<span class="stLiteral">1</span>)
-m expects (<span class="stLiteral">2</span>)
-m(<span class="stLiteral">2</span>)
-m(<span class="stLiteral">1</span>)
-</pre>
-
-<p>A specific sequence can be enforced with <code>inSequence</code>:</p>
-
-<pre class="stHighlighted">
-inSequence {
-  m expects (<span class="stLiteral">1</span>)
-  m expects (<span class="stLiteral">2</span>)
-}
-m(<span class="stLiteral">2</span>) // throws ExpectationException
-m(<span class="stLiteral">1</span>)
-</pre>
-
-<p>Multiple sequences can be specified. As long as the calls within each sequence happen in the
-correct order, calls within different sequences can be interleaved. For example:</p>
-
-<pre class="stHighlighted">
-<span class="stReserved">val</span> m1 = mock[<span class="stType">Turtle</span>]
-<span class="stReserved">val</span> m2 = mock[<span class="stType">Turtle</span>]
-
-inSequence {
-  m1.expects.setPosition(<span class="stLiteral">0.0</span>, <span class="stLiteral">0.0</span>)
-  m1.expects.penDown
-  m1.expects.forward(<span class="stLiteral">10.0</span>)
-  m1.expects.penUp
-}
-inSequence {
-  m2.expects.setPosition(<span class="stLiteral">1.0</span>, <span class="stLiteral">1.0</span>)
-  m2.expects.turn(<span class="stLiteral">90.0</span>)
-  m2.expects.forward(<span class="stLiteral">1.0</span>)
-  m2.expects.getPosition returning (<span class="stLiteral">2.0</span>, <span class="stLiteral">1.0</span>)
-}
-
-m2.setPosition(<span class="stLiteral">1.0</span>, <span class="stLiteral">1.0</span>)
-m1.setPosition(<span class="stLiteral"> 0.0</span>, <span class="stLiteral">0.0</span>)
-m1.penDown
-m2.turn(<span class="stLiteral">90.0</span>)
-m1.forward(<span class="stLiteral">10.0</span>)
-m2.forward(<span class="stLiteral">1.0</span>)
-m1.penUp
-expect((<span class="stLiteral">2.0</span>, <span class="stLiteral">1.0</span>)) { m2.getPosition }
-</pre>
-
-<p>To specify that there is no constraint on ordering, use <code>inAnyOrder</code> (there is an implicit
-<code>inAnyOrder</code> at the top level). Calls to <code>inSequence</code> and <code>inAnyOrder</code> can be arbitrarily
-nested. For example:</p>
-
-<pre class="stHighlighted">
-m.expects.a
-inSequence {
-  m.expects.b
-  inAnyOrder {
-    m.expects.c
-    inSequence {
-      m.expects.d
-      m.expects.e
-    }
-    m.expects.f
-  }
-  m.expects.g
+  (heaterStub.setPowerState _).verify(<span class="stType">PowerState</span>.On)
+  (heaterStub.setPowerState _).verify(<span class="stType">PowerState</span>.Off)
 }
 </pre>
 
-<h2>Debugging</h2>
+<p>You can read more about ScalaMock mocking styles in its <a href="http://scalamock.org/user-guide/mocking_style">User Guide</a>.</p>
 
-<p>If faced with a difficult to debug failing expectation, consider mixing
-one or both of the <code>org.scalamock.VerboseErrors</code> or <code>org.scalamock.CallLogging</code> traits
-into your test suite:</p>
+<h2 id="argument-matching">Argument Matching</h2>
 
-<pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">MockFactory</span> <span class="stReserved">with</span>
-    <span class="stType">VerboseErrors</span> <span class="stReserved">with</span> <span class="stType">CallLogging</span> ...
+<p>ScalaMock supports three types of generalised matching: </p>
+
+<ul>
+  <li>wildcards</li>
+  <li>epsilon matching</li>
+  <li>predicate matching</li>
+</ul>
+
+<pre class="stHighlighted"><span class="stLineComment">// expect someMethod("foo", 42) to be called</span>
+(myMock.someMethod _).expects(<span class="stLiteral">"foo"</span>, <span class="stLiteral">42</span>)  
+
+<span class="stLineComment">// expect someMethod("foo", x) to be called for some integer x</span>
+(myMock.someMethod _).expects(<span class="stLiteral">"foo"</span>, *)      
+
+<span class="stLineComment">// expect someMethod("foo", x) to be called for some float x that is close to 42.0</span>
+(myMock.otherMethod _).expects(<span class="stLiteral">"foo"</span>, ~<span class="stLiteral">42.0</span>)
+
+<span class="stLineComment">// expect sendMessage(receiver, message) for some receiver with name starting with "A"</span>
+(myMock.sendMessage _).expects(where { (receiver: <span class="stType">Player</span>, message: <span class="stType">Message</span>) =&gt; 
+    receiver.name.startsWith(<span class="stLiteral">"A"</span>)
+}) 
+</pre>
+
+<h2 id="ordering">Ordering</h2>
+<p>By default, expectations can be satisfied in any order. A specific sequence can be enforced with <code>inSequence</code></p>
+<pre class="stHighlighted"><span class="stLineComment">// expect that machine is turned on before turning it off</span>
+inSequence {
+  (machineMock.turnOn _).expects()
+  (machineMock.turnOff _).expects()
+}
+
+<span class="stLineComment">// players can be fetched in any order</span>
+inAnyOrder {
+  (databaseMock.getPlayerByName _).expects(<span class="stLiteral">"Hans"</span>)
+  (databaseMock.getPlayerByName _).expects(<span class="stLiteral">"Boris"</span>)
+}
+</pre>
+
+<h2 id="call-counts">Call counts</h2>
+<p>By default, mocks and stubs expect exactly one call. But you can also specify alternative constraints, for example:</p>
+
+<pre class="stHighlighted"><span class="stLineComment">// expect message to be sent twice</span>
+(myMock.sendMessage _).expects(*).twice
+
+<span class="stLineComment">// expect message to be sent any number of times</span>
+(myMock.sendMessage _).expects(*).anyNumberOfTimes
+
+<span class="stLineComment">// expect message to be sent no more than twice</span>
+(myMock.sendMessage _).expects(*).noMoreThanTwice
+</pre>
+
+<h2 id="returning-values">Returning values</h2>
+
+<p>By default mocks and stubs return <code>null</code>. You can return predefined value using <code>returning()</code> method (or <code>returns()</code> in case of stubs).</p>
+<pre class="stHighlighted">(databaseMock.getPlayerByName _).expects(<span class="stLiteral">"Hans"</span>).returning(<span class="stType">Player</span>(name=<span class="stLiteral">"Hans"</span>, country=<span class="stLiteral">"Germany"</span>))
+(databaseMock.getPlayerByName _).expects(<span class="stLiteral">"Boris"</span>).returning(<span class="stType">Player</span>(name=<span class="stLiteral">"Hans"</span>, country=<span class="stLiteral">"Russia"</span>))
+</pre>
+
+<h2 id="throwing-exceptions">Throwing exceptions</h2>
+
+Instead of a return value, mocks and stubs can be instructed to throw. This can be achieved by using <code>throwing</code> method.
+
+<pre class="stHighlighted">(databaseMock.getPlayerByName _).expects(<span class="stLiteral">"George"</span>).throwing(<span class="stReserved">new</span> <span class="stType">NoSuchElementException</span>)</pre>
+
+<h2 id="call-handlers">Call handlers</h2>
+
+<p> When returned value depends on function arguments, you can return the computed value (or throw a computed exception) with <code>onCall()</code>.</p>
+
+<pre class="stHighlighted"><span class="stLineComment">// compute returned value</span>
+(fooMock.increment _) expects(*) onCall { arg: <span class="stType">Int</span> =&gt; arg + <span class="stLiteral">1</span>}
+fooMock.increment(<span class="stLiteral">100</span>) shouldBe <span class="stLiteral">101</span>
+
+<span class="stLineComment">// throw computed exception</span>
+(fooMock.increment _) expects(*) onCall { arg: <span class="stType">Int</span> =&gt; throw <span class="stReserved">new</span> <span class="stType">RuntimeException</span>(arg) }
 </pre>
 
 <a name="easyMock"></a>


### PR DESCRIPTION
ScalaTest user guide section related to ScalaMock was **really** outdated. I've updated it to use the correct syntax and removed information about things that don't exist in ScalaMock 3 anymore (compiler plugin, etc.)
