### PR TITLE
ScalaTest+Play 1.4.0

### DIFF
--- a/app/views/plus/playVersions.scala.html
+++ b/app/views/plus/playVersions.scala.html
@@ -31,7 +31,7 @@ Click on the <em>ScalaTest + Play</em> to visit the Scaladoc for that release.
 <table style="border-collapse: collapse; border: 1px solid black">
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + Play Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">Play Versions</th></tr>
 <tr>
-<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="http://doc.scalatest.org/plus-play/1.0.0/#package">1.4.0-M4</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="http://doc.scalatest.org/plus-play/1.0.0/#package">1.4.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.2.x</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.4.x</td>
 </tr>


### PR DESCRIPTION
Updated Versions, Versions, Versions page to use ScalaTest+Play version 1.4.0 for ScalaTest 2.2.x and Play 2.4.x.