### PR TITLE
ScalaCheck 1.12.5 (not 1.12.6)

### DIFF
--- a/app/views/releaseNotes/v226.scala.html
+++ b/app/views/releaseNotes/v226.scala.html
@@ -38,7 +38,7 @@ see its <a href="http://www.scalactic.org/download">download page</a>.
 <h2>Enhancement</h2>
 
 <ul>
-<li>Updated the ScalaCheck dependency to version 1.12.6.</li>
+<li>Updated the ScalaCheck dependency to version 1.12.5.</li>
 </ul>
 
 <a name="bugFixes"></a>


### PR DESCRIPTION
I think it is 1.12.5 instead of 1.12.6.

See:
https://www.scalacheck.org/releases.html
There is no 1.12.6 (after 1.12.5, the next version is 1.13.0)

See:
http://mvnrepository.com/artifact/org.scalatest/scalatest_2.11/2.2.6
http://mvnrepository.com/artifact/org.scalatest/scalatest_2.10/2.2.6

The compile dependency points to 1.12.5, not 1.12.6
