### PR TITLE
Adding 1.5 version of ScalaTest Plus for the Play framework 2.5

### DIFF
--- a/app/views/plus/playFramework.scala.html
+++ b/app/views/plus/playFramework.scala.html
@@ -25,8 +25,8 @@ For an overview, see the documentation on the Play Framework website:
 </p>
 
 <ul>
-<li><a href="http://www.playframework.com/documentation/2.2.x/ScalaTestingWithScalaTest">Testing your application with ScalaTest</a></li>
-<li><a href="http://www.playframework.com/documentation/2.2.x/ScalaFunctionalTestingWithScalaTest">Writing functional tests with ScalaTest</a></li>
+<li><a href="http://www.playframework.com/documentation/2.5.x/ScalaTestingWithScalaTest">Testing your application with ScalaTest</a></li>
+<li><a href="http://www.playframework.com/documentation/2.5.x/ScalaFunctionalTestingWithScalaTest">Writing functional tests with ScalaTest</a></li>
 </ul>
 
 <p>

--- a/app/views/plus/playVersions.scala.html
+++ b/app/views/plus/playVersions.scala.html
@@ -31,6 +31,11 @@ Click on the <em>ScalaTest + Play</em> to visit the Scaladoc for that release.
 <table style="border-collapse: collapse; border: 1px solid black">
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + Play Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">Play Versions</th></tr>
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="http://doc.scalatest.org/plus-play/1.0.0/#package">1.5.1</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.2.x</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.5.x</td>
+</tr>
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="http://doc.scalatest.org/plus-play/1.0.0/#package">1.4.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.2.x</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.4.x</td>


### PR DESCRIPTION
Play is now on v2.5. And scalatest's play plus library is at v 1.5.1 atm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scalatest/scalatest-website/55)
<!-- Reviewable:end -->
