### PR TITLE
Address minor typos in usingMatchers text

### DIFF
--- a/app/views/userGuide/usingMatchers.scala.html
+++ b/app/views/userGuide/usingMatchers.scala.html
@@ -705,7 +705,7 @@ are in sorted order, like this:</p>
 <a name="workingWithIterators"> </a>
 <h2> Working with iterators </h2>
 
-<p>Althought it seems desireable to provide similar matcher syntax for Scala and Java iterators to that provided for sequences like
+<p>Although it seems desirable to provide similar matcher syntax for Scala and Java iterators to that provided for sequences like
 <code>Seq</code>s, <code>Array</code>, and <code>java.util.List</code>, the
 ephemeral nature of iterators makes this problematic. Some syntax (such as <code>should</code> <code>contain</code>) is relatively straightforward to
 support on iterators, but other syntax (such
@@ -864,7 +864,7 @@ javaMap should contain (<span class="stType">Entry</span>(<span class="stLiteral
 javaMap should contain oneOf (<span class="stType">Entry</span>(<span class="stLiteral">2</span>, <span class="stLiteral">3</span>), <span class="stType">Entry</span>(<span class="stLiteral">3</span>, <span class="stLiteral">4</span>))
 </pre></p>
 
-<p>You can you alse just check whether a Java <code>Map</code> contains a particular key, or value, like this:</p>
+<p>You can also just check whether a Java <code>Map</code> contains a particular key, or value, like this:</p>
 
 <p><pre class="stHighlighted">
 javaMap should contain key <span class="stLiteral">1</span>
@@ -983,7 +983,7 @@ to a syntax error), use:</p>
 
 <p>
 Note that the <code>shouldNot</code> <code>typeCheck</code> syntax will only succeed if the given snippet of code does not
-compile because of a type error. A syntax error will still result on a thrown <code>TestFailedException</code>.
+compile because of a type error. A syntax error will still result in a thrown <code>TestFailedException</code>.
 </p>
 
 <p>If you want to state that a snippet of code <em>does</em> compile, you can make that
@@ -1157,12 +1157,12 @@ book should have (
 <p>This expression will use reflection to ensure the <code>title</code>, <code>author</code>, and <code>pubYear</code> properties of object <code>book</code>
 are equal to the specified values. For example, it will ensure that <code>book</code> has either a public Java field or method
 named <code>title</code>, or a public method named <code>getTitle</code>, that when invoked (or accessed in the field case) results
-in a the string <code>"Programming in Scala"</code>. If all specified properties exist and have their expected values, respectively,
+in the string <code>"Programming in Scala"</code>. If all specified properties exist and have their expected values, respectively,
 execution will continue. If one or more of the properties either does not exist, or exists but results in an unexpected value,
 a <code>TestFailedException</code> will be thrown that explains the problem. (For the details on how a field or method is selected during this
 process, see the documentation for <a href="@latestScaladoc/#org.scalatest.Matchers$HavePropertyMatcherGenerator"><code>HavePropertyMatcherGenerator</code></a>.)</p>
 
-<p>When you use this syntax, you must place one or more property values in parentheses after <code>have</code>, seperated by commas, where a <em>property
+<p>When you use this syntax, you must place one or more property values in parentheses after <code>have</code>, separated by commas, where a <em>property
 value</em> is a symbol indicating the name of the property followed by the expected value in parentheses. The only exceptions to this rule is the syntax
 for checking size and length shown previously, which does not require parentheses. If you forget and put parentheses in, however, everything will
 still work as you'd expect. Thus instead of writing:</p>
@@ -1365,13 +1365,13 @@ please see the documentation for <a href="@latestScaladoc/#org.scalatest.matcher
 <span class="stReserved">val</span> hidden = <span class="stQuotedString">'hidden</span>
 </pre></p>
 
-<p>Now you can check that an file is hidden without the tick mark:</p>
+<p>Now you can check that a file is hidden without the tick mark:</p>
 
 <p><pre class="stHighlighted">
 <span class="stReserved">new</span> <span class="stType">File</span>(<span class="stQuotedString">&quot;secret.txt&quot;</span>) should be (hidden)
 </pre></p>
 
-<p>You could get rid of the parens with by using <code>shouldBe</code>:</p>
+<p>You could get rid of the parens by using <code>shouldBe</code>:</p>
 
 <p><pre class="stHighlighted">
 <span class="stReserved">new</span> <span class="stType">File</span>(<span class="stQuotedString">&quot;secret.txt&quot;</span>) shouldBe hidden
@@ -1474,7 +1474,7 @@ beAsIntsGreaterThan: String =&gt; org.scalatest.matchers.Matcher[String] = &lt;f
 scala&gt; &quot;8&quot; should beAsIntsGreaterThan (&quot;7&quot;)
 </pre>
 
-<p>At thsi point, however, the error message for the <code>beAsIntsGreaterThan</code>
+<p>At this point, however, the error message for the <code>beAsIntsGreaterThan</code>
 gives no hint that the <code>Int</code>s being compared were parsed from <code>String</code>s:</p>
 
 <pre class="stREPL">
@@ -1537,7 +1537,7 @@ org.scalatest.exceptions.TestFailedException: &quot;7&quot;.toInt was not greate
 </pre>
 
 
-<a name="expectedExceptions"></a>
+<a name="#checkingForExpectedExceptions"></a>
 <h2> Checking for expected exceptions </h2>
 
 <p>Sometimes you need to test whether a method throws an expected exception under certain circumstances, such
@@ -1552,7 +1552,7 @@ an [<span class="stType">IndexOutOfBoundsException</span>] should be thrownBy s.
 this expression will result in that exception. But if <code>charAt</code> completes normally, or throws a different
 exception, this expression will complete abruptly with a <code>TestFailedException</code>.</p>
 
-<p>If you need to further isnpect an expected exception, you can capture it using this syntax:</p>
+<p>If you need to further inspect an expected exception, you can capture it using this syntax:</p>
 
 <p><pre class="stHighlighted">
 <span class="stReserved">val</span> thrown = the [<span class="stType">IndexOutOfBoundsException</span>] thrownBy s.charAt(-<span class="stLiteral">1</span>)


### PR DESCRIPTION
Correct link to "Checking for expected exceptions" and other minor
typos.