### PR TITLE
Fix some broken scaladoc link on `Testing with mock objects` page

### DIFF
--- a/app/views/userGuide/testingWithMockObjects.scala.html
+++ b/app/views/userGuide/testingWithMockObjects.scala.html
@@ -399,7 +399,7 @@ into your test suite:</p>
 <h1>Using EasyMock</h1>
 
 <p>
-ScalaTest's <a href="@latestScaladoc/#org.scalatest.mock.EasyMockSugar"><code>EasyMockSugar</code></a> trait provides some basic syntax sugar for <a href="http://easymock.org/" target="_blank">EasyMock</a>.
+ScalaTest's <a href="@latestScaladoc/#org.scalatest.easymock.EasyMockSugar"><code>EasyMockSugar</code></a> trait provides some basic syntax sugar for <a href="http://easymock.org/" target="_blank">EasyMock</a>.
 </p>
 
 <p>
@@ -529,7 +529,7 @@ takes an implicit <code>MockObjects</code> parameter. Here's how that would look
 <h1>Using JMock</h1>
 
 <p>
-ScalaTest's <a href="@latestScaladoc/#org.scalatest.mock.JMockCycle"><code>JMockCycle</code></a> class, which wraps and manages the lifecycle of a single <code>org.jmock.Mockery</code> context object,
+ScalaTest's <a href="@latestScaladoc/#org.scalatest.jmock.JMockCycle"><code>JMockCycle</code></a> class, which wraps and manages the lifecycle of a single <code>org.jmock.Mockery</code> context object,
 provides some basic syntax sugar for using <a href="http://www.jmock.org/" target="_blank">JMock</a> in Scala.
 </p>
 
@@ -683,7 +683,7 @@ To summarize, here's what a typical test using <code>JMockCycle</code> looks lik
 </pre>
 
 <p>
-ScalaTest also provides a <a href="@latestScaladoc/#org.scalatest.mock.JMockCycleFixture"><code>JMockCycleFixture</code></a> trait, which
+ScalaTest also provides a <a href="@latestScaladoc/#org.scalatest.jmock.JMockCycleFixture"><code>JMockCycleFixture</code></a> trait, which
 will pass a new <code>JMockCycle</code> into each test that needs one.
 </p>
 
@@ -691,7 +691,7 @@ will pass a new <code>JMockCycle</code> into each test that needs one.
 <h1>Using Mockito</h1>
 
 <p>
-ScalaTest's <a href="@latestScaladoc/#org.scalatest.mock.MockitoSugar"><code>MockitoSugar</code></a> trait provides some basic syntax sugar for <a href="http://mockito.org/" target="_blank">Mockito</a>.
+ScalaTest's <a href="@latestScaladoc/#org.scalatest.mockito.MockitoSugar"><code>MockitoSugar</code></a> trait provides some basic syntax sugar for <a href="http://mockito.org/" target="_blank">Mockito</a>.
 </p>
 
 <p>


### PR DESCRIPTION
fix EasyMockSugar, JMockCycle, JMockCycleFixture, MockitoSugar scaladoc link.
