### PR TITLE
mention 2.13.0 support in install.html

### DIFF
--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -27,7 +27,7 @@
 <h1>Installing ScalaTest</h1>
 
 <p>
-<strong>ScalaTest and Scalactic @{latestVersion}</strong> (the latest release for Scala 2.10.0+, 2.11.0+, and 2.12.0+)
+<strong>ScalaTest and Scalactic @{latestVersion}</strong> (the latest release for Scala 2.10.0+, 2.11.0+, 2.12.0+, and 2.13.0+)
 
 <ul>
 <li><a href="/release_notes/@{latestVersion}">Combined @{latestVersion} Release Notes</a></li>


### PR DESCRIPTION
Since ScalaTest and Scalactic 3.0.8 support Scala 2.13.0, let me add its description into install.html .