### PR TITLE
Update style traits and matchers for 3.2.x in documentation

### DIFF
--- a/app/views/userGuide/OptionValues.scala.html
+++ b/app/views/userGuide/OptionValues.scala.html
@@ -24,7 +24,7 @@
 <p>
 ScalaTest has many other traits and classes that can help you address specific problems.
 This page gives tutorials on just a few of them. 
-For the full list, see <a href="@routes.Assets.at("/public/scaladoc", "2.0/index.html#org.scalatest.FlatSpec")">ScalaTest's Scaladoc documentation</a>.
+For the full list, see <a href="@routes.Assets.at("/public/scaladoc", "2.0/index.html#org.scalatest.flatspec.AnyFlatSpec")">ScalaTest's Scaladoc documentation</a>.
 </p>
 
 <p>

--- a/app/views/userGuide/definingBaseClasses.scala.html
+++ b/app/views/userGuide/definingBaseClasses.scala.html
@@ -37,7 +37,7 @@ a <code>UnitSpec</code> class (not trait, for speedier compiles) for unit tests 
 
 <span class="stReserved">import</span> org.scalatest._
 
-<span class="stReserved">abstract</span> <span class="stReserved">class</span> <span class="stType">UnitSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> <span class="stReserved">with</span>
+<span class="stReserved">abstract</span> <span class="stReserved">class</span> <span class="stType">UnitSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> <span class="stReserved">with</span>
   <span class="stType">OptionValues</span> <span class="stReserved">with</span> <span class="stType">Inside</span> <span class="stReserved">with</span> <span class="stType">Inspectors</span>
 </pre>
 

--- a/app/views/userGuide/definingBaseClasses.scala.html
+++ b/app/views/userGuide/definingBaseClasses.scala.html
@@ -36,8 +36,9 @@ a <code>UnitSpec</code> class (not trait, for speedier compiles) for unit tests 
 <span class="stReserved">package</span> com.mycompany.myproject
 
 <span class="stReserved">import</span> org.scalatest._
+<span class="stReserved">import</span> matchers._
 
-<span class="stReserved">abstract</span> <span class="stReserved">class</span> <span class="stType">UnitSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> <span class="stReserved">with</span>
+<span class="stReserved">abstract</span> <span class="stReserved">class</span> <span class="stType">UnitSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">should.Matchers</span> <span class="stReserved">with</span>
   <span class="stType">OptionValues</span> <span class="stReserved">with</span> <span class="stType">Inside</span> <span class="stReserved">with</span> <span class="stType">Inspectors</span>
 </pre>
 

--- a/app/views/userGuide/generatorDrivenPropertyChecks.scala.html
+++ b/app/views/userGuide/generatorDrivenPropertyChecks.scala.html
@@ -52,7 +52,7 @@ For an example of trait <code>GeneratorDrivenPropertyChecks</code> in action, im
 
 <p>
 To test the behavior of <code>Fraction</code>, you could mix in or import the members of <code>GeneratorDrivenPropertyChecks</code>
-(and <a href="@latestScaladoc/#org.scalatest.matchers.ShouldMatchers"><code>ShouldMatchers</code></a>) and check a property using a <code>forAll</code> method, like this:
+(and <a href="@latestScaladoc/#org.scalatest.matchers.should.Matchers"><code>should.Matchers</code></a>) and check a property using a <code>forAll</code> method, like this:
 </p>
 
 <pre class="stHighlighted">

--- a/app/views/userGuide/matchersQuickReference.scala.html
+++ b/app/views/userGuide/matchersQuickReference.scala.html
@@ -207,7 +207,7 @@ caught.getMessage should be (<span class="stQuotedString">"String index out of r
 
 <tr>
 <td class="quickref"><code>emptySet should be (<span class="stQuotedString">'empty</span>)</code></td>
-<td class="quickref">Accesses <code>empty</code> or <code>isEmpty</code> dynamically (For the details on how a field or method is dynamically selected, see the documentation for <a href="@latestScaladoc/#org.scalatest.matchers.Matchers$BeWord"><code>BeWord</code></a>.)</td>
+<td class="quickref">Accesses <code>empty</code> or <code>isEmpty</code> dynamically (For the details on how a field or method is dynamically selected, see the documentation for <a href="@latestScaladoc/#org.scalatest.matchers.dsl.BeWord"><code>BeWord</code></a>.)</td>
 </tr>
 
 <tr>

--- a/app/views/userGuide/otherGoodies.scala.html
+++ b/app/views/userGuide/otherGoodies.scala.html
@@ -24,7 +24,7 @@
 <p>
 ScalaTest has many other traits and classes that can help you address specific problems.
 This page gives tutorials on just a few of them. 
-For the full list, see <a href="@routes.Assets.at("/public/scaladoc", "2.0/index.html#org.scalatest.FlatSpec")">ScalaTest's Scaladoc documentation</a>.
+For the full list, see <a href="@routes.Assets.at("/public/scaladoc", "2.0/index.html#org.scalatest.flatspec.AnyFlatSpec")">ScalaTest's Scaladoc documentation</a>.
 </p>
 
 <p>

--- a/app/views/userGuide/philosophyAndDesign.scala.html
+++ b/app/views/userGuide/philosophyAndDesign.scala.html
@@ -75,7 +75,7 @@ users.
 Scala is a scalable language in two ways. First, Scala can be molded through library and DSL design to fit widely different tasks. Second, Scala
 scales both down to small tasks and up to large ones. It feels as natural to use for small tasks like scripting as it does for large tasks like major software projects built
 by large teams. ScalaTest is scalable in similar ways. First, it can be easily molded by overriding its <em>lifecycle methods</em> to address
-special testing needs when they arise. Second, it is designed facilitate both small tasks in the Scala interpreter (see <a href="@latestScaladoc/#org.scalatest.Assertions$"><code>Assertions</code></a>, <a href="@latestScaladoc/#org.scalatest.matchers.ShouldMatchers$"><code>ShouldMatchers</code></a>,
+special testing needs when they arise. Second, it is designed facilitate both small tasks in the Scala interpreter (see <a href="@latestScaladoc/#org.scalatest.Assertions$"><code>Assertions</code></a>, <a href="@latestScaladoc/#org.scalatest.matchers.should.Matchers$"><code>should.Matchers</code></a>,
 and the ScalaTest <a href="@latestScaladoc/#org.scalatest.Shell"><code>Shell</code></a>) and to scale up to testing 
 very large software projects built by large teams.
 </p>

--- a/app/views/userGuide/philosophyAndDesign.scala.html
+++ b/app/views/userGuide/philosophyAndDesign.scala.html
@@ -178,9 +178,9 @@ which simply invokes the function.
 <p>
 How does this design enable ScalaTest to address widely different testing needs? You need look no further than ScalaTest itself
 for examples. First, ScalaTest facilitates several different styles of testing through its <em>style traits</em> such as
-<a href="@latestScaladoc/#org.scalatest.FunSuite"><code>FunSuite</code></a>,
-<a href="@latestScaladoc/#org.scalatest.FunSpec"><code>FunSpec</code></a>, and
-<a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</code></a>. One way to think of these style traits is as examples of ScalaTest using
+<a href="@latestScaladoc/#org.scalatest.funsuite.AnyFunSuite"><code>AnyFunSuite</code></a>,
+<a href="@latestScaladoc/#org.scalatest.funspec.AnyFunSpec"><code>AnyFunSpec</code></a>, and
+<a href="@latestScaladoc/#org.scalatest.featurespec.AnyFeatureSpec"><code>AnyFeatureSpec</code></a>. One way to think of these style traits is as examples of ScalaTest using
 its own extension points to customize itself. All three override the same five lifecycle methods: <code>run</code>, <code>runTests</code>, <code>testNames</code>,
 <code>tags</code>, and <code>runTest</code>. They inherit the remaining lifecycle methods as is from their supertrait <code>Suite</code>.
 </p>
@@ -222,9 +222,9 @@ time to invest in becoming an expert in a test framework.
 One way in which ScalaTest is designed for teams is that it is easy to get started with because it offers styles
 <em>familiar</em> to many users. Users of <a href="@latestScaladoc/#org.scalatest.junit.JUnitSuite">JUnit</a> or <a href="@latestScaladoc/#org.scalatest.testng.TestNGSuite">TestNG</a>, for example, can
 continue using those tools with a few productivity enhancements from ScalaTest sprinkled in. Or if they use
-<a href="/getting_started_with_fun_suite"><code>FunSuite</code> with <code>Assertions</code></a>, they'll find an even nicer DSL for testing that still makes sense
-given their xUnit background. Users of RSpec will find <a href="@latestScaladoc/#org.scalatest.FunSpec"><code>FunSpec</code></a> familiar and easy to get into. Users of Cucumber
-will find <a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</code></a> familiar. In short, one of ScalaTest's design goals is that anyone
+<a href="/getting_started_with_fun_suite"><code>AnyFunSuite</code> with <code>Assertions</code></a>, they'll find an even nicer DSL for testing that still makes sense
+given their xUnit background. Users of RSpec will find <a href="@latestScaladoc/#org.scalatest.funspec.AnyFunSpec"><code>AnyFunSpec</code></a> familiar and easy to get into. Users of Cucumber
+will find <a href="@latestScaladoc/#org.scalatest.featurespec.AnyFeatureSpec"><code>AnyFeatureSpec</code></a> familiar. In short, one of ScalaTest's design goals is that anyone
 who has used a test framework in the past should be able to get going with ScalaTest quickly with minimum effort.
 </p>
 

--- a/app/views/userGuide/selectingAStyle.scala.html
+++ b/app/views/userGuide/selectingAStyle.scala.html
@@ -193,9 +193,10 @@ choice for writing the occasional test matrix when a different style trait is ch
 </p>
 <pre class="stStyleExamples">
 <span class="stReserved">import</span> org.scalatest._
+<span class="stReserved">import</span> matchers._
 <span class="stReserved">import</span> prop._
 <span class="stReserved">import</span> scala.collection.immutable._
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyPropSpec</span> <span class="stReserved">with</span> <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyPropSpec</span> <span class="stReserved">with</span> <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">should.Matchers</span> {
 <br />  <span class="stReserved">val</span> examples =
     <span class="stType">Table</span>(
       <span class="stQuotedString">&quot;set&quot;</span>,

--- a/app/views/userGuide/selectingAStyle.scala.html
+++ b/app/views/userGuide/selectingAStyle.scala.html
@@ -32,7 +32,7 @@ This allows the testing styles to fit the team while maintaining uniformity in t
 We recommend you select one main style for unit testing and another for acceptance testing.
 Using a different style for unit and acceptance testing can help developers "switch gears" between 
 low-level unit testing to high-level acceptance testing. You may also want to select particular styles to be used in special situations, such as using
-<a href="@latestScaladoc/#org.scalatest.PropSpec@@testMatrix"><code>PropSpec</code> for test matrixes</a>. 
+<a href="@latestScaladoc/#org.scalatest.propspec.AnyPropSpec@@testMatrix"><code>AnyPropSpec</code> for test matrixes</a>. 
 We usually write integration tests&mdash;tests that involve subsystems such as a database&mdash;in the same style as the unit tests.
 </p>
 
@@ -51,9 +51,9 @@ mixin traits, <em>etc.</em>&mdash;works consistently the same way no matter what
 
 <p>
 If you would rather be told which approach to take rather than pick one yourself, we recommend you use
-<a href="@latestScaladoc/#org.scalatest.FlatSpec"><code>FlatSpec</code></a> for unit and integration testing and
-<a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</code></a> for acceptance testing.
-We recommend <code>FlatSpec</code> as the default choice, because it is flat (unnested) like the XUnit tests familiar to most developers, but
+<a href="@latestScaladoc/#org.scalatest.flatspec.AnyFlatSpec"><code>AnyFlatSpec</code></a> for unit and integration testing and
+<a href="@latestScaladoc/#org.scalatest.featurespec.AnyFeatureSpec"><code>AnyFeatureSpec</code></a> for acceptance testing.
+We recommend <code>AnyFlatSpec</code> as the default choice, because it is flat (unnested) like the XUnit tests familiar to most developers, but
 guides you into writing focused tests with descriptive, specification-style names.
 </p>
 
@@ -69,11 +69,11 @@ information and examples, click on the links:
 <table style="border-collapse: collapse; border: 1px solid black">
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">Style Trait Descriptions and Examples</th></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>FunSuite</h2>
-<p class="stStyleDesc">For teams coming from xUnit, <a href="@latestScaladoc/#org.scalatest.FunSuite"><code>FunSuite</code></a> feels comfortable and familiar while still giving some of the benefits of BDD: <code>FunSuite</code> makes it easy to write descriptive test names, natural to write focused tests, and generates specification-like output that can facilitate communication among stakeholders.</p>
+<h2>AnyFunSuite</h2>
+<p class="stStyleDesc">For teams coming from xUnit, <a href="@latestScaladoc/#org.scalatest.funsuite.AnyFunSuite"><code>AnyFunSuite</code></a> feels comfortable and familiar while still giving some of the benefits of BDD: <code>AnyFunSuite</code> makes it easy to write descriptive test names, natural to write focused tests, and generates specification-like output that can facilitate communication among stakeholders.</p>
 <pre class="stStyleExamples">
-<span class="stReserved">import</span> org.scalatest.FunSuite
-<br /><span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+<span class="stReserved">import</span> org.scalatest.funsuite.AnyFunSuite
+<br /><span class="stReserved">class</span> <span class="stType">SetSuite</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSuite</span> {
 <br />  test(<span class="stQuotedString">&quot;An empty Set should have size 0&quot;</span>) {
     assert(Set.empty.size == <span class="stLiteral">0</span>)
   }
@@ -88,13 +88,13 @@ information and examples, click on the links:
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>FlatSpec</h2>
+<h2>AnyFlatSpec</h2>
 <p class="stStyleDesc">
-A good first step for teams wishing to move from xUnit to BDD, <a href="@latestScaladoc/#org.scalatest.FlatSpec"><code>FlatSpec</code></a>'s structure is
+A good first step for teams wishing to move from xUnit to BDD, <a href="@latestScaladoc/#org.scalatest.flatspec.AnyFlatSpec"><code>AnyFlatSpec</code></a>'s structure is
 flat like xUnit, so simple and familiar, but the test names must be written in a specification style: "X should Y," "A must B," <em>etc</em>.</p>
 <pre class="stStyleExamples">
-<span class="stReserved">import</span> org.scalatest.FlatSpec
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stQuotedString">&quot;An empty Set&quot;</span> should <span class="stQuotedString">&quot;have size 0&quot;</span> in {
     assert(Set.empty.size == <span class="stLiteral">0</span>)
   }
@@ -109,15 +109,15 @@ flat like xUnit, so simple and familiar, but the test names must be written in a
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>FunSpec</h2>
+<h2>AnyFunSpec</h2>
 <p class="stStyleDesc">
-For teams coming from Ruby's RSpec tool, <a href="@latestScaladoc/#org.scalatest.FunSpec"><code>FunSpec</code></a> will feel very familiar; More generally, for any team that prefers BDD,
-<code>FunSpec</code>'s nesting and gentle guide to structuring text (with <code>describe</code> and <code>it</code>) provides an excellent
+For teams coming from Ruby's RSpec tool, <a href="@latestScaladoc/#org.scalatest.funspec.AnyFunSpec"><code>AnyFunSpec</code></a> will feel very familiar; More generally, for any team that prefers BDD,
+<code>AnyFunSpec</code>'s nesting and gentle guide to structuring text (with <code>describe</code> and <code>it</code>) provides an excellent
 general-purpose choice for writing specification-style tests.
 </p>
 <pre class="stStyleExamples">
-<span class="stReserved">import</span> org.scalatest.FunSpec
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+<span class="stReserved">import</span> org.scalatest.funspec.AnyFunSpec
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSpec</span> {
 <br />  describe(<span class="stQuotedString">&quot;A Set&quot;</span>) {
     describe(<span class="stQuotedString">&quot;when empty&quot;</span>) {
       it(<span class="stQuotedString">&quot;should have size 0&quot;</span>) {
@@ -136,13 +136,13 @@ general-purpose choice for writing specification-style tests.
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>WordSpec</h2>
+<h2>AnyWordSpec</h2>
 <p class="stStyleDesc">
-For teams coming from specs or specs2, <a href="@latestScaladoc/#org.scalatest.WordSpec"><code>WordSpec</code></a> will feel familiar, and is often the most natural way to port specsN tests to ScalaTest. <code>WordSpec</code> is very prescriptive in how text must be written, so a good fit for teams who want a high degree of discipline enforced upon their specification text.
+For teams coming from specs or specs2, <a href="@latestScaladoc/#org.scalatest.wordspec.AnyWordSpec"><code>AnyWordSpec</code></a> will feel familiar, and is often the most natural way to port specsN tests to ScalaTest. <code>AnyWordSpec</code> is very prescriptive in how text must be written, so a good fit for teams who want a high degree of discipline enforced upon their specification text.
 </p>
 <pre class="stStyleExamples">
-<span class="stReserved">import</span> org.scalatest.WordSpec
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">WordSpec</span> {
+<span class="stReserved">import</span> org.scalatest.wordspec.AnyWordSpec
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyWordSpec</span> {
 <br />  <span class="stQuotedString">&quot;A Set&quot;</span> when {
     <span class="stQuotedString">&quot;empty&quot;</span> should {
       <span class="stQuotedString">&quot;have size 0&quot;</span> in {
@@ -161,13 +161,13 @@ For teams coming from specs or specs2, <a href="@latestScaladoc/#org.scalatest.W
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>FreeSpec</h2>
+<h2>AnyFreeSpec</h2>
 <p class="stStyleDesc">
-Because it gives absolute freedom (and no guidance) on how specification text should be written, <a href="@latestScaladoc/#org.scalatest.FreeSpec"><code>FreeSpec</code></a> is a good choice for teams experienced with BDD and able to agree on how to structure the specification text.
+Because it gives absolute freedom (and no guidance) on how specification text should be written, <a href="@latestScaladoc/#org.scalatest.freespec.AnyFreeSpec"><code>AnyFreeSpec</code></a> is a good choice for teams experienced with BDD and able to agree on how to structure the specification text.
 </p>
 <pre class="stStyleExamples">
-<span class="stReserved">import</span> org.scalatest.FreeSpec
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">FreeSpec</span> {
+<span class="stReserved">import</span> org.scalatest.freespec.AnyFreeSpec
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFreeSpec</span> {
 <br />  <span class="stQuotedString">&quot;A Set&quot;</span> - {
     <span class="stQuotedString">&quot;when empty&quot;</span> - {
       <span class="stQuotedString">&quot;should have size 0&quot;</span> in {
@@ -186,16 +186,16 @@ Because it gives absolute freedom (and no guidance) on how specification text sh
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>PropSpec</h2>
+<h2>AnyPropSpec</h2>
 <p class="stStyleDesc">
-<a href="@latestScaladoc/#org.scalatest.PropSpec">PropSpec</a> is perfect for teams that want to write tests exclusively in terms of property checks; also a good
+<a href="@latestScaladoc/#org.scalatest.propspec.AnyPropSpec">AnyPropSpec</a> is perfect for teams that want to write tests exclusively in terms of property checks; also a good
 choice for writing the occasional test matrix when a different style trait is chosen as the main unit testing style.
 </p>
 <pre class="stStyleExamples">
 <span class="stReserved">import</span> org.scalatest._
 <span class="stReserved">import</span> prop._
 <span class="stReserved">import</span> scala.collection.immutable._
-<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">PropSpec</span> <span class="stReserved">with</span> <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
+<br /><span class="stReserved">class</span> <span class="stType">SetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyPropSpec</span> <span class="stReserved">with</span> <span class="stType">TableDrivenPropertyChecks</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> {
 <br />  <span class="stReserved">val</span> examples =
     <span class="stType">Table</span>(
       <span class="stQuotedString">&quot;set&quot;</span>,
@@ -219,9 +219,9 @@ choice for writing the occasional test matrix when a different style trait is ch
 </tr>
 
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">
-<h2>FeatureSpec</h2>
+<h2>AnyFeatureSpec</h2>
 <p class="stStyleDesc">
-Trait <a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</code></a> is primarily intended for acceptance testing, including facilitating the process of programmers working alongside non-programmers to define the acceptance requirements.
+Trait <a href="@latestScaladoc/#org.scalatest.featurespec.AnyFeatureSpec"><code>AnyFeatureSpec</code></a> is primarily intended for acceptance testing, including facilitating the process of programmers working alongside non-programmers to define the acceptance requirements.
 </p>
 <pre class="stStyleExamples">
 <span class="stReserved">import</span> org.scalatest._
@@ -232,7 +232,7 @@ Trait <a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</co
     on = !on
   }
 }
-<br /><span class="stReserved">class</span> <span class="stType">TVSetSpec</span> <span class="stReserved">extends</span> <span class="stType">FeatureSpec</span> <span class="stReserved">with</span> <span class="stType">GivenWhenThen</span> {
+<br /><span class="stReserved">class</span> <span class="stType">TVSetSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFeatureSpec</span> <span class="stReserved">with</span> <span class="stType">GivenWhenThen</span> {
 <br />  info(<span class="stQuotedString">&quot;As a TV set owner&quot;</span>)
   info(<span class="stQuotedString">&quot;I want to be able to turn the TV on and off&quot;</span>)
   info(<span class="stQuotedString">&quot;So I can watch TV when I want&quot;</span>)

--- a/app/views/userGuide/sharingFixtures.scala.html
+++ b/app/views/userGuide/sharingFixtures.scala.html
@@ -157,9 +157,9 @@ test that needs the fixture, storing the returned object or objects in local var
 
 <p><pre class="stHighlighted">
 <span class="stReserved">package</span> org.scalatest.examples.flatspec.getfixture
-<br /><span class="stReserved">import</span> org.scalatest.FlatSpec
+<br /><span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
 <span class="stReserved">import</span> collection.mutable.ListBuffer
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stReserved">def</span> fixture =
     <span class="stReserved">new</span> {
       <span class="stReserved">val</span> builder = <span class="stReserved">new</span> <span class="stType">StringBuilder</span>(<span class="stQuotedString">&quot;ScalaTest is &quot;</span>)
@@ -201,8 +201,8 @@ and each test just mixes together the traits it needs:</p>
 <p><pre class="stHighlighted">
 <span class="stReserved">package</span> org.scalatest.examples.flatspec.fixturecontext
 <br /><span class="stReserved">import</span> collection.mutable.ListBuffer
-<span class="stReserved">import</span> org.scalatest.FlatSpec
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stReserved">trait</span> <span class="stType">Builder</span> {
     <span class="stReserved">val</span> builder = <span class="stReserved">new</span> <span class="stType">StringBuilder</span>(<span class="stQuotedString">&quot;ScalaTest is &quot;</span>)
   }
@@ -275,7 +275,7 @@ send that information to the reporter:</p>
 <span class="stReserved">package</span> org.scalatest.examples.flatspec.noargtest
 <br /><span class="stReserved">import</span> java.io.File
 <span class="stReserved">import</span> org.scalatest._
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stReserved">override</span> <span class="stReserved">def</span> withFixture(test: <span class="stType">NoArgTest</span>) = {
 <br />    <span class="stReserved">super</span>.withFixture(test) <span class="stReserved">match</span> {
       <span class="stReserved">case</span> failed: <span class="stType">Failed</span> =&gt;
@@ -338,11 +338,11 @@ loan-fixture method. (In this example, the database is simulated with a <code>St
     databases.remove(name)
   }
 }
-<br /><span class="stReserved">import</span> org.scalatest.FlatSpec
+<br /><span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
 <span class="stReserved">import</span> DbServer._
 <span class="stReserved">import</span> java.util.UUID.randomUUID
 <span class="stReserved">import</span> java.io._
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stReserved">def</span> withDatabase(testCode: <span class="stType">Db</span> =&gt; <span class="stType">Any</span>) {
     <span class="stReserved">val</span> dbName = randomUUID.toString
     <span class="stReserved">val</span> db = createDb(dbName) <span class="stLineComment">// create the fixture</span>
@@ -395,9 +395,9 @@ done in this example. This keeps tests completely isolated, allowing you to run 
 <p></pre>
 <a name="withFixtureOneArgTest"></a></p><h4> Overriding <code>withFixture(OneArgTest)</code> </h4>
 
-<p>If all or most tests need the same fixture, you can avoid some of the boilerplate of the loan-fixture method approach by using a <code>fixture.FlatSpec</code>
+<p>If all or most tests need the same fixture, you can avoid some of the boilerplate of the loan-fixture method approach by using a <code>fixture.AnyFlatSpec</code>
 and overriding <code>withFixture(OneArgTest)</code>.
-Each test in a <code>fixture.FlatSpec</code> takes a fixture as a parameter, allowing you to pass the fixture into
+Each test in a <code>fixture.AnyFlatSpec</code> takes a fixture as a parameter, allowing you to pass the fixture into
 the test. You must indicate the type of the fixture parameter by specifying <code>FixtureParam</code>, and implement a
 <code>withFixture</code> method that takes a <code>OneArgTest</code>. This <code>withFixture</code> method is responsible for
 invoking the one-arg test function, so you can perform fixture set up before, and clean up after, invoking and passing
@@ -420,7 +420,7 @@ withFixture(test.toNoArgTest(theFixture))
 <span class="stReserved">package</span> org.scalatest.examples.flatspec.oneargtest
 <br /><span class="stReserved">import</span> org.scalatest.fixture
 <span class="stReserved">import</span> java.io._
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">fixture.AnyFlatSpec</span> {
 <br />  <span class="stReserved">case</span> <span class="stReserved">class</span> <span class="stType">FixtureParam</span>(file: <span class="stType">File</span>, writer: <span class="stType">FileWriter</span>)
 <br />  <span class="stReserved">def</span> withFixture(test: <span class="stType">OneArgTest</span>) = {
     <span class="stReserved">val</span> file = File.createTempFile(<span class="stQuotedString">&quot;hello&quot;</span>, <span class="stQuotedString">&quot;world&quot;</span>) <span class="stLineComment">// create the fixture</span>
@@ -447,7 +447,7 @@ withFixture(test.toNoArgTest(theFixture))
 
 <p>In this example, the tests actually required two fixture objects, a <code>File</code> and a <code>FileWriter</code>. In such situations you can
 simply define the <code>FixtureParam</code> type to be a tuple containing the objects, or as is done in this example, a case class containing
-the objects.  For more information on the <code>withFixture(OneArgTest)</code> technique, see the <a href="@latestScaladoc/#org.scalatest.fixture.FlatSpec">documentation for <code>fixture.FlatSpec</code></a>.</p>
+the objects.  For more information on the <code>withFixture(OneArgTest)</code> technique, see the <a href="@latestScaladoc/#org.scalatest.fixture.AnyFlatSpec">documentation for <code>fixture.AnyFlatSpec</code></a>.</p>
 
 <p><a name="beforeAndAfter"> </a></p><h4> Mixing in <code>BeforeAndAfter</code> </h4>
 
@@ -462,7 +462,7 @@ with <code>before</code> and/or after each test each test with <code>after</code
 <span class="stReserved">package</span> org.scalatest.examples.flatspec.beforeandafter
 <br /><span class="stReserved">import</span> org.scalatest._
 <span class="stReserved">import</span> collection.mutable.ListBuffer
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">BeforeAndAfter</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">BeforeAndAfter</span> {
 <br />  <span class="stReserved">val</span> builder = <span class="stReserved">new</span> <span class="stType">StringBuilder</span>
   <span class="stReserved">val</span> buffer = <span class="stReserved">new</span> <span class="stType">ListBuffer[String]</span>
 <br />  before {
@@ -527,7 +527,7 @@ factored out into two <em>stackable fixture traits</em> named <code>Builder</cod
     <span class="stReserved">finally</span> buffer.clear()
   }
 }
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">Builder</span> <span class="stReserved">with</span> <span class="stType">Buffer</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Builder</span> <span class="stReserved">with</span> <span class="stType">Buffer</span> {
 <br />  <span class="stQuotedString">&quot;Testing&quot;</span> should <span class="stQuotedString">&quot;be easy&quot;</span> in {
     builder.append(<span class="stQuotedString">&quot;easy!&quot;</span>)
     assert(builder.toString === <span class="stQuotedString">&quot;ScalaTest is easy!&quot;</span>)
@@ -588,7 +588,7 @@ were rewritten to use the <code>BeforeAndAfterEach</code> methods instead of <co
     <span class="stReserved">finally</span> buffer.clear()
   }
 }
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">Builder</span> <span class="stReserved">with</span> <span class="stType">Buffer</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Builder</span> <span class="stReserved">with</span> <span class="stType">Buffer</span> {
 <br />  <span class="stQuotedString">&quot;Testing&quot;</span> should <span class="stQuotedString">&quot;be easy&quot;</span> in {
     builder.append(<span class="stQuotedString">&quot;easy!&quot;</span>)
     assert(builder.toString === <span class="stQuotedString">&quot;ScalaTest is easy!&quot;</span>)

--- a/app/views/userGuide/sharingTests.scala.html
+++ b/app/views/userGuide/sharingTests.scala.html
@@ -20,9 +20,9 @@
 <h1>Sharing tests</h1>
 
 <p>Sometimes you may want to run the same test code on different fixture objects. In other words, you may want to write tests that are &quot;shared&quot;
-by different fixture objects.  To accomplish this in a <code>FlatSpec</code>, you first place shared tests in <em>behavior functions</em>.
-These behavior functions will be invoked during the construction phase of any <code>FlatSpec</code> that uses them, so that the tests they
-contain will be registered as tests in that <code>FlatSpec</code>.  For example, given this stack class:</p><p><pre class="stHighlighted">
+by different fixture objects.  To accomplish this in a <code>AnyFlatSpec</code>, you first place shared tests in <em>behavior functions</em>.
+These behavior functions will be invoked during the construction phase of any <code>AnyFlatSpec</code> that uses them, so that the tests they
+contain will be registered as tests in that <code>AnyFlatSpec</code>.  For example, given this stack class:</p><p><pre class="stHighlighted">
 <span class="stReserved">import</span> scala.collection.mutable.ListBuffer
 <br /><span class="stReserved">class</span> <span class="stType">Stack[T]</span> {
 <br />  <span class="stReserved">val</span> MAX = <span class="stLiteral">10</span>
@@ -54,13 +54,13 @@ contain will be registered as tests in that <code>FlatSpec</code>.  For example,
 <em>etc</em>. You may find you have several tests that make sense any time the stack is non-empty. Thus you'd ideally want to run
 those same tests for three stack fixture objects: a full stack, a stack with a one item, and a stack with one item less than
 capacity. With shared tests, you can factor these tests out into a behavior function, into which you pass the
-stack fixture to use when running the tests. So in your <code>FlatSpec</code> for stack, you'd invoke the
+stack fixture to use when running the tests. So in your <code>AnyFlatSpec</code> for stack, you'd invoke the
 behavior function three times, passing in each of the three stack fixtures so that the shared tests are run for all three fixtures. You
-can define a behavior function that encapsulates these shared tests inside the <code>FlatSpec</code> that uses them. If they are shared
-between different <code>FlatSpec</code>s, however, you could also define them in a separate trait that is mixed into each <code>FlatSpec</code>
+can define a behavior function that encapsulates these shared tests inside the <code>AnyFlatSpec</code> that uses them. If they are shared
+between different <code>AnyFlatSpec</code>s, however, you could also define them in a separate trait that is mixed into each <code>AnyFlatSpec</code>
 that uses them.</p><p><a name="StackBehaviors">For</a> example, here the <code>nonEmptyStack</code> behavior function (in this case, a behavior <em>method</em>) is
 defined in a trait along with another method containing shared tests for non-full stacks:</p><p><pre class="stHighlighted">
-<span class="stReserved">trait</span> <span class="stType">StackBehaviors</span> { <span class="stReserved">this</span>: <span class="stType">FlatSpec</span> =&gt;
+<span class="stReserved">trait</span> <span class="stType">StackBehaviors</span> { <span class="stReserved">this</span>: <span class="stType">AnyFlatSpec</span> =&gt;
 <br />  <span class="stReserved">def</span> nonEmptyStack(newStack: =&gt; <span class="stType">Stack[Int]</span>, lastItemAdded: <span class="stType">Int</span>) {
 <br />    it should <span class="stQuotedString">&quot;be non-empty&quot;</span> in {
       assert(!newStack.empty)
@@ -94,7 +94,7 @@ defined in a trait along with another method containing shared tests for non-ful
     }
   }
 }
-</pre></p><p>Given these behavior functions, you could invoke them directly, but <code>FlatSpec</code> offers a DSL for the purpose,
+</pre></p><p>Given these behavior functions, you could invoke them directly, but <code>AnyFlatSpec</code> offers a DSL for the purpose,
 which looks like this:</p><p><pre class="stHighlighted">
 it should behave like nonEmptyStack(stackWithOneItem, lastValuePushed)
 it should behave like nonFullStack(stackWithOneItem)
@@ -105,7 +105,7 @@ in scope already inside the behavior function. In that case, your code would loo
 it should behave like nonEmptyStack <span class="stLineComment">// assuming lastValuePushed is also in scope inside nonEmptyStack</span>
 it should behave like nonFullStack
 </pre></p><p>The recommended style, however, is the functional, pass-all-the-needed-values-in style. Here's an example:</p><p><pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">SharedTestExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">StackBehaviors</span> {
+<span class="stReserved">class</span> <span class="stType">SharedTestExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">StackBehaviors</span> {
 <br />  <span class="stLineComment">// Stack fixture creation methods</span>
   <span class="stReserved">def</span> emptyStack = <span class="stReserved">new</span> <span class="stType">Stack[Int]</span>
 <br />  <span class="stReserved">def</span> fullStack = {
@@ -184,10 +184,10 @@ A Stack (full)
 - should complain on a push</span>
 </pre></p><p>One thing to keep in mind when using shared tests is that in ScalaTest, each test in a suite must have a unique name.
 If you register the same tests repeatedly in the same suite, one problem you may encounter is an exception at runtime
-complaining that multiple tests are being registered with the same test name. A good way to solve this problem in a <code>FlatSpec</code> is to make sure
+complaining that multiple tests are being registered with the same test name. A good way to solve this problem in a <code>AnyFlatSpec</code> is to make sure
 each invocation of a behavior function is in the context of a different subject,
 which will prepend a string to each test name.
-For example, the following code in a <code>FlatSpec</code> would register a test with the name <code>"A Stack (when empty) should be empty"</code>:</p><p><pre class="stHighlighted">
+For example, the following code in a <code>AnyFlatSpec</code> would register a test with the name <code>"A Stack (when empty) should be empty"</code>:</p><p><pre class="stHighlighted">
 behavior of <span class="stQuotedString">&quot;A Stack (when empty)&quot;</span>
 <br />it should <span class="stQuotedString">&quot;be empty&quot;</span> in {
   assert(emptyStack.empty)

--- a/app/views/userGuide/tableDrivenPropertyChecks.scala.html
+++ b/app/views/userGuide/tableDrivenPropertyChecks.scala.html
@@ -94,7 +94,7 @@ You could then check a property against each row of the table using a <code>forA
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.matchers.ShouldMatchers._
+<span class="stReserved">import</span> org.scalatest.matchers.should.Matchers._
 <br />forAll (fractions) { (n: <span class="stType">Int</span>, d: <span class="stType">Int</span>) =>
 <br />  whenever (d != <span class="stLiteral">0</span> && d != Integer.MIN_VALUE
       && n != Integer.MIN_VALUE) {

--- a/app/views/userGuide/taggingYourTests.scala.html
+++ b/app/views/userGuide/taggingYourTests.scala.html
@@ -31,13 +31,13 @@ one tag by default: ignore. You can tag a test as ignored to "switch it off" tem
 <p>
 To support the common use case of &#8220;temporarily&#8221; disabling a test, with the
 good intention of resurrecting the test at a later time, each style trait provides a way to tag tests as ignored.
-For example, in a <code>FlatSpec</code> you can change an <code>it</code> or an <code>in</code> to <code>ignore</code>:
+For example, in a <code>AnyFlatSpec</code> you can change an <code>it</code> or an <code>in</code> to <code>ignore</code>:
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FlatSpec
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
 <span class="stReserved">import</span> scala.collection.mutable.Stack
-<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stQuotedString">&quot;A Stack&quot;</span> should <span class="stQuotedString">&quot;pop values in last-in-first-out order&quot;</span> in {
       <span class="stReserved">val</span> stack = <span class="stReserved">new</span> <span class="stType">Stack[Int]</span>
       stack.push(<span class="stLiteral">1</span>)
@@ -75,7 +75,7 @@ It will run only the first test and report that the second test was ignored:
 <h2>Defining and using your own tags</h2>
 
 <p>
-Each style trait provides a way to tag tests. To tag tests in a <code>FlatSpec</code>, for example,
+Each style trait provides a way to tag tests. To tag tests in a <code>AnyFlatSpec</code>, for example,
 you pass objects that extend abstract class <code>org.scalatest.Tag</code> to <code>taggedAs</code>
 just before the <code>in</code>. Class <code>Tag</code> takes one parameter, a string name.
 Here's how you might define tags to mark tests that require a database:
@@ -87,13 +87,13 @@ Here's how you might define tags to mark tests that require a database:
 </pre>
 
 <p>
-Given this definitions, you could tag <code>FlatSpec</code> tests like this:
+Given this definitions, you could tag <code>AnyFlatSpec</code> tests like this:
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FlatSpec
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
 <span class="stReserved">import</span> org.scalatest.tagobjects.Slow
-<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stQuotedString">&quot;The Scala language&quot;</span> must <span class="stQuotedString">&quot;add correctly&quot;</span> taggedAs(<span class="stType">Slow</span>) in {
       <span class="stReserved">val</span> sum = <span class="stLiteral">1</span> + <span class="stLiteral">1</span>
       assert(sum === <span class="stLiteral">2</span>)

--- a/app/views/userGuide/testingWithMockObjects.scala.html
+++ b/app/views/userGuide/testingWithMockObjects.scala.html
@@ -74,10 +74,10 @@ classUnderTest.addDocument(<span class="stQuotedString">"Document"</span>, <span
 as in:
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FlatSpec
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
 <span class="stReserved">import</span> org.scalamock.scalatest.MockFactory
 
-class <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">FlatSpec</span> <span class="stReserved">with <span class="stType">MockFactory</span> <span class="stReserved">with ...
+class <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with <span class="stType">MockFactory</span> <span class="stReserved">with ...
 </pre>
 
 <h2>Function mocks</h2>
@@ -391,7 +391,7 @@ one or both of the <code>org.scalamock.VerboseErrors</code> or <code>org.scalamo
 into your test suite:</p>
 
 <pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">MockFactory</span> <span class="stReserved">with</span>
+<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends<span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">MockFactory</span> <span class="stReserved">with</span>
     <span class="stType">VerboseErrors</span> <span class="stReserved">with</span> <span class="stType">CallLogging</span> ...
 </pre>
 

--- a/app/views/userGuide/testsAsSpecifications.scala.html
+++ b/app/views/userGuide/testsAsSpecifications.scala.html
@@ -29,14 +29,14 @@ can be executed to verify that behavior. ScalaTest provides rich support for thi
 <p>
 In BDD, test names are sentences that specify a bit of desired behavior that the body of the test will ensure is working. This keeps tests focused
 on just one thing, making it easier to figure out what behavior has been broken when a test fails. To keep the focus on specifying behavior, the word
-&ldquo;test&rdquo; disappears from the source code and is replaced with words that make the code feel more like a specification. For example, in ScalaTest's <a href="@latestScaladoc/#org.scalatest.FunSpec"><code>FunSpec</code></a> trait, you use
-the word &ldquo;describe&rdquo; to name and qualify the subject under test, and &ldquo;it&rdquo; to mark the beginning of a sentence about a bit of the subject's behavior.  Here's an example <code>FunSpec</code>:
+&ldquo;test&rdquo; disappears from the source code and is replaced with words that make the code feel more like a specification. For example, in ScalaTest's <a href="@latestScaladoc/#org.scalatest.funspec.AnyFunSpec"><code>AnyFunSpec</code></a> trait, you use
+the word &ldquo;describe&rdquo; to name and qualify the subject under test, and &ldquo;it&rdquo; to mark the beginning of a sentence about a bit of the subject's behavior.  Here's an example <code>AnyFunSpec</code>:
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FunSpec
+<span class="stReserved">import</span> org.scalatest.funspec.AnyFunSpec
 <span class="stReserved">import</span> scala.collection.mutable.Stack
-<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSpec</span> {
 <br />  describe(<span class="stQuotedString">"A Stack"</span>) {
 <br />    it(<span class="stQuotedString">"should pop values in last-in-first-out order"</span>) {
       <span class="stReserved">val</span> stack = <span class="stReserved">new</span> <span class="stType">Stack[Int]</span>
@@ -84,10 +84,10 @@ mixing in trait <code>GivenWhenThen</code> would enable you to write code like:
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FunSpec
+<span class="stReserved">import</span> org.scalatest.funspec.AnyFunSpec
 <span class="stReserved">import</span> org.scalatest.GivenWhenThen
 <span class="stReserved">import</span> scala.collection.mutable.Stack
-<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> <span class="stReserved">with</span> <span class="stType">GivenWhenThen</span> {
+<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSpec</span> <span class="stReserved">with</span> <span class="stType">GivenWhenThen</span> {
 <br />  describe(<span class="stQuotedString">"A Stack"</span>) {
 <br />    it(<span class="stQuotedString">"should pop values in last-in-first-out-order"</span>) {
 <br />      given(<span class="stQuotedString">"a non-empty stack"</span>)
@@ -136,12 +136,12 @@ Were you to run this <code>StackSpec</code> in the Scala interpreter, you would 
 </pre>
 
 <p>
-ScalaTest provides many traits that facilitate BDD style: Compared to <a href="@latestScaladoc/#org.scalatest.FunSpec"><code>Spec</code></a>,
-<a href="@latestScaladoc/#org.scalatest.WordSpec"><code>WordSpec</code></a> and <a href="@latestScaladoc/#org.scalatest.FlatSpec"><code>FlatSpec</code></a> provide more gramatical structure (<em>e.g.</em>,
+ScalaTest provides many traits that facilitate BDD style: Compared to <a href="@latestScaladoc/#org.scalatest.funspec.AnyFunSpec"><code>Spec</code></a>,
+<a href="@latestScaladoc/#org.scalatest.wordspec.AnyWordSpec"><code>AnyWordSpec</code></a> and <a href="@latestScaladoc/#org.scalatest.flatspec.AnyFlatSpec"><code>AnyFlatSpec</code></a> provide more gramatical structure (<em>e.g.</em>,
 test names must include <code>should</code>, <code>can</code>, or <code>must</code>), whereas
-<a href="@latestScaladoc/#org.scalatest.FreeSpec"><code>FreeSpec</code></a> gives complete freedom to the writer. Other BDD traits facilitate specific kinds of
-testing: <a href="@latestScaladoc/#org.scalatest.FeatureSpec"><code>FeatureSpec</code></a>'s syntax
-is geared towards acceptance, integration, and functional testing, and <a href="@latestScaladoc/#org.scalatest.PropSpec"><code>PropSpec</code></a>
+<a href="@latestScaladoc/#org.scalatest.freespec.AnyFreeSpec"><code>AnyFreeSpec</code></a> gives complete freedom to the writer. Other BDD traits facilitate specific kinds of
+testing: <a href="@latestScaladoc/#org.scalatest.featurespec.AnyFeatureSpec"><code>AnyFeatureSpec</code></a>'s syntax
+is geared towards acceptance, integration, and functional testing, and <a href="@latestScaladoc/#org.scalatest.propspec.AnyPropSpec"><code>AnyPropSpec</code></a>
 is geared towards property-based testing.
 </p>
 

--- a/app/views/userGuide/usingJunitRunner.scala.html
+++ b/app/views/userGuide/usingJunitRunner.scala.html
@@ -26,9 +26,9 @@ ScalaTest <code>Suite</code>. Here's an example:
 <pre class="stHighlighted">
 <span class="stReserved">import</span> org.junit.runner.RunWith
 <span class="stReserved">import</span> org.scalatest.junit.JUnitRunner
-<span class="stReserved">import</span> org.scalatest.FunSuite
+<span class="stReserved">import</span> org.scalatest.funsuite.AnyFunSuite
 <br />@@<span class="stType">RunWith</span>(classOf[<span class="stType">JUnitRunner</span>])
-<span class="stReserved">class</span> <span class="stType">ExampleSuite</span> <span class="stReserved">extends</span> <span class="stType">FunSuite</span> {
+<span class="stReserved">class</span> <span class="stType">ExampleSuite</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSuite</span> {
   <span class="stLineComment">// ...</span>
 }
 </pre>

--- a/app/views/userGuide/usingMatchers.scala.html
+++ b/app/views/userGuide/usingMatchers.scala.html
@@ -30,23 +30,24 @@
 
 <p>
 ScalaTest provides a domain specific language (DSL) for expressing assertions in tests
-using the word <code>should</code>. Just mix in <a href="@latestScaladoc/#org.scalatest.Matchers"><code>Matchers</code></a>, like this:
+using the word <code>should</code>. Just mix in <a href="@latestScaladoc/#org.scalatest.matchers.should.Matchers"><code>should.Matchers</code></a>, like this:
 </p>
 
 <pre class="stHighlighted">
 <span class="stReserved">import</span> org.scalatest._
+<span class="stReserved">import</span> matchers.should._
 
 <span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> &#123; ...
 </pre>
 
 <p>
 You can alternatively import the members of the trait, a technique particularly useful when you want to try out matcher expressions in the 
-Scala interpreter. Here's an example where the members of <code>Matchers</code> are imported:
+Scala interpreter. Here's an example where the members of <code>should.Matchers</code> are imported:
 </p>
 
 <pre class="stHighlighted">
 <span class="stReserved">import</span> org.scalatest._
-<span class="stReserved">import</span> Matchers._
+<span class="stReserved">import</span> matchers.should.Matchers._
 
 <span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> &#123; // Can use matchers here ...
 </pre>
@@ -91,7 +92,7 @@ Here is a table of contents for this page:
 <li><a href="#thosePeskyParens">Those pesky parens</a></li>
 </ul>
 
-<p>If you mix <code>Matchers</code> into
+<p>If you mix <code>should.Matchers</code> into
 a suite class, you can write an equality assertion in that suite like this:</p>
 
 <p><pre class="stHighlighted">
@@ -105,7 +106,7 @@ will be thrown with a detail message that explains the problem, such as <code>"7
 This <code>TestFailedException</code> will cause the test to fail.</p>
 
 <p>
-Trait <a href="@latestScaladoc/#org.scalatest.MustMatchers"><code>MustMatchers</code></a> is an alternative to <a href="@latestScaladoc/#org.scalatest.Matchers"><code>Matchers</code></a> that provides the exact same meaning, syntax, and behavior as <code>Matchers</code>, but
+Trait <a href="@latestScaladoc/#org.scalatest.matchers.must.Matchers"><code>must.Matchers</code></a> is an alternative to <a href="@latestScaladoc/#org.scalatest.matchers.should.Matchers"><code>should.Matchers</code></a> that provides the exact same meaning, syntax, and behavior as <code>should.Matchers</code>, but
 uses the verb <code>must</code> instead of <code>should</code>. The two traits differ only in the English semantics of the verb: <code>should</code> is informal,
 making the code feel like conversation between the writer and the reader; <code>must</code> is more formal, making the code feel more like a written specification.
 </p>
@@ -162,8 +163,8 @@ simple &quot;explictly&quot; DSL. For example, here's how you could explicitly s
 sides (which must be strings), by transforming them to lowercase:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; import org.scalactic.Explicitly._
 import org.scalactic.Explicitly._
@@ -187,8 +188,8 @@ an implicit <code>Equality[T]</code> each time.</p>
 constraints at compile-time between the left and right sides of the equality comparison. Here's an example:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; import org.scalactic.TypeCheckedTripleEquals._
 import org.scalactic.TypeCheckedTripleEquals._
@@ -439,8 +440,8 @@ The <code>Emptiness</code> companion object provides implicits for <code>GenTrav
 returns a <code>Boolean</code>. Here are some examples:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; List.empty shouldBe empty
 
@@ -474,8 +475,8 @@ companion object, implicits are provided for types <code>GenTraversable[E]</code
 Here are some examples:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; List(1, 2, 3) should contain (2)
 
@@ -499,8 +500,8 @@ implicit conversions are provided in the <code>Containing</code> companion objec
 types of containers of <code>E</code>. Here's an example:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; List(&quot;Hi&quot;, &quot;Di&quot;, &quot;Ho&quot;) should contain (&quot;ho&quot;)
 org.scalatest.exceptions.TestFailedException: List(Hi, Di, Ho) did not contain element &quot;ho&quot;
@@ -769,8 +770,8 @@ All of the inspectors have shorthands in matchers. Here is the full list:</p><ul
 <p>Here are some examples:</p>
 
 <pre class="stREPL">
-scala&gt; import org.scalatest.Matchers._
-import org.scalatest.Matchers._
+scala&gt; import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 scala&gt; val xs = List(1, 2, 3, 4, 5)
 xs: List[Int] = List(1, 2, 3, 4, 5)
@@ -880,8 +881,8 @@ javaMap should contain value <span class="stQuotedString">&quot;Howdy&quot;</spa
 scala&gt; import org.scalatest._
 import org.scalatest._
 
-scala&gt; import Matchers._
-import Matchers._
+scala&gt; import matchers.should.Matchers._
+import matchers.should.Matchers._
 
 scala&gt; atLeast (2, Array(1, 2, 3)) should be &gt; 1
 
@@ -969,7 +970,7 @@ string should not startWith (<span class="stQuotedString">&quot;Hello&quot;</spa
 
 <p>Often when creating libraries you may wish to ensure that certain arrangements of code that
 represent potential &ldquo;user errors&rdquo; do not compile, so that your library is more error resistant.
-ScalaTest <code>Matchers</code> trait includes the following syntax for that purpose:</p>
+ScalaTest <code>should.Matchers</code> trait includes the following syntax for that purpose:</p>
 
 <pre class="stHighlighted">
 <span class="stQuotedString">&quot;val a: String = 1&quot;</span> shouldNot compile
@@ -1333,7 +1334,7 @@ s<span class="stQuotedString">&quot;&quot;&quot;File $name did not end with exte
 
 <p><pre class="stHighlighted">
 <span class="stReserved">import</span> org.scalatest._
-<span class="stReserved">import</span> Matchers._
+<span class="stReserved">import</span> matchers.should.Matchers._
 <span class="stReserved">import</span> java.io.File
 <span class="stReserved">import</span> CustomMatchers._
 <br /><span class="stReserved">new</span> <span class="stType">File</span>(<span class="stQuotedString">&quot;essay.text&quot;</span>) should endWithExtension (<span class="stQuotedString">&quot;txt&quot;</span>)
@@ -1440,8 +1441,8 @@ can be more easily created by composing a function with the existing <code>endWi
 scala&gt; import org.scalatest._
 import org.scalatest._
 
-scala&gt; import Matchers._
-import Matchers._
+scala&gt; import matchers.should.Matchers._
+import matchers.should.Matchers._
 
 scala&gt; import java.io.File
 import java.io.File
@@ -1542,7 +1543,7 @@ org.scalatest.exceptions.TestFailedException: &quot;7&quot;.toInt was not greate
 <h2> Checking for expected exceptions </h2>
 
 <p>Sometimes you need to test whether a method throws an expected exception under certain circumstances, such
-as when invalid arguments are passed to the method. With <code>Matchers</code> mixed in, you can
+as when invalid arguments are passed to the method. With <code>should.Matchers</code> mixed in, you can
 check for an expected exception like this:</p>
 
 <p><pre class="stHighlighted">

--- a/app/views/userGuide/usingMatchers.scala.html
+++ b/app/views/userGuide/usingMatchers.scala.html
@@ -318,7 +318,7 @@ non-empty iterator was not traversableAgain
 not have an appropriately named predicate method, you'll get a <code>TestFailedException</code>
 at runtime with a detailed message that explains the problem.
 (For the details on how a field or method is selected during this
-process, see the documentation for <a href="@latestScaladoc/#org.scalatest.words.BeWord"><code>BeWord</code></a>.)</p>
+process, see the documentation for <a href="@latestScaladoc/#org.scalatest.matchers.dsl.BeWord"><code>BeWord</code></a>.)</p>
 
 <p>If you think it reads better, you can optionally put <code>a</code> or <code>an</code> after
 <code>be</code>. For example, <code>java.io.File</code> has two predicate methods,

--- a/app/views/userGuide/usingMatchers.scala.html
+++ b/app/views/userGuide/usingMatchers.scala.html
@@ -36,7 +36,7 @@ using the word <code>should</code>. Just mix in <a href="@latestScaladoc/#org.sc
 <pre class="stHighlighted">
 <span class="stReserved">import</span> org.scalatest._
 
-<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> &#123; ...
+<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">Matchers</span> &#123; ...
 </pre>
 
 <p>
@@ -48,7 +48,7 @@ Scala interpreter. Here's an example where the members of <code>Matchers</code> 
 <span class="stReserved">import</span> org.scalatest._
 <span class="stReserved">import</span> Matchers._
 
-<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> &#123; // Can use matchers here ...
+<span class="stReserved">class</span> <span class="stType">ExampleSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> &#123; // Can use matchers here ...
 </pre>
 
 <p>

--- a/app/views/userGuide/usingScalaJS.scala.html
+++ b/app/views/userGuide/usingScalaJS.scala.html
@@ -39,7 +39,7 @@
 <span class="stReserved">import</span> org.scalatest._
 <span class="stReserved">import</span> org.scalajs.jquery.<span class="stType">jQuery</span>
 
-<span class="stReserved">class</span> <span class="stType">TutorialTestWithScalaTest</span> <span class="stReserved">extends</span> <span class="stType">FunSpec</span> {
+<span class="stReserved">class</span> <span class="stType">TutorialTestWithScalaTest</span> <span class="stReserved">extends</span> <span class="stType">AnyFunSpec</span> {
 
   <span class="stLineComment">// Initialize App</span>
   <span class="stType">TutorialApp</span>.setupUI()

--- a/app/views/userGuide/usingScalatestWithSbt.scala.html
+++ b/app/views/userGuide/usingScalatestWithSbt.scala.html
@@ -269,29 +269,29 @@ You can specify tag names of tests to include or exclude from a run. To specify 
 </p>
 
 <p>
- To facilitate the communication and enforcement of a team's style choices for a project, you can specify the chosen styles in your project build. If chosen styles is defined, ScalaTest style traits that are not among the chosen list will abort with a message complaining that the style trait is not one of the chosen styles. The style name for each ScalaTest style trait is its fully qualified name. For example, to specify that <code>org.scalatest.FunSpec</code> as your chosen style you'd pass this to ScalaTest in your sbt build file:
+ To facilitate the communication and enforcement of a team's style choices for a project, you can specify the chosen styles in your project build. If chosen styles is defined, ScalaTest style traits that are not among the chosen list will abort with a message complaining that the style trait is not one of the chosen styles. The style name for each ScalaTest style trait is its fully qualified name. For example, to specify that <code>org.scalatest.funspec.AnyFunSpec</code> as your chosen style you'd pass this to ScalaTest in your sbt build file:
 </p>
 
 <pre class="stGrayback">
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.FunSpec")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.funspec.AnyFunSpec")
 </pre>
 
 <p>
-If you wanted <code>org.scalatest.FunSpec</code> as your main unit testing style, but also wanted to allow <code>PropSpec</code> for test matrixes and FeatureSpec for integration tests, you would write:
+If you wanted <code>org.scalatest.funspec.AnyFunSpec</code> as your main unit testing style, but also wanted to allow <code>AnyPropSpec</code> for test matrixes and AnyFeatureSpec for integration tests, you would write:
 </p>
 
 <pre class="stGrayback">
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.FunSpec",
-    "-y", "org.scalatest.PropSpec", "-y", "org.scalatest.FeatureSpec")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.funspec.AnyFunSpec",
+    "-y", "org.scalatest.propspec.AnyPropSpec", "-y", "org.scalatest.featurespec.AnyFeatureSpec")
 </pre>
 
 <p>
- To select <code>org.scalatest.FlatSpec</code> as your main unit testing style, but allow <code>org.scalatest.fixture.FlatSpec</code> for multi-threaded unit tests, you'd write:
+ To select <code>org.scalatest.flatspec.AnyFlatSpec</code> as your main unit testing style, but allow <code>org.scalatest.fixture.AnyFlatSpec</code> for multi-threaded unit tests, you'd write:
 </p>
 
 <pre class="stGrayback">
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.FlatSpec",
-    "-y", "org.scalatest.fixture.FlatSpec")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-y", "org.scalatest.flatspec.AnyFlatSpec",
+    "-y", "org.scalatest.fixture.AnyFlatSpec")
 </pre>
 
 <p>

--- a/app/views/userGuide/usingSelenium.scala.html
+++ b/app/views/userGuide/usingSelenium.scala.html
@@ -37,7 +37,7 @@ libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "@latestSel
 entirety except for one missing piece: an implicit <code>org.openqa.selenium.WebDriver</code>. One way to provide the missing
 implicit driver is to declare one as a member of your test class, like this:</p><p>
 <pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">WebBrowser</span> {
+<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">should.Matchers</span> <span class="stReserved">with</span> <span class="stType">WebBrowser</span> {
 
   <span class="stReserved">implicit</span> <span class="stReserved">val</span> webDriver: <span class="stType">WebDriver</span> = <span class="stReserved">new</span> <span class="stType">HtmlUnitDriver</span>
 
@@ -52,7 +52,7 @@ implicit driver is to declare one as a member of your test class, like this:</p>
 driver provided by Selenium.
 Thus a simpler way to use the <code>HtmlUnit</code> driver, for example, is to extend
 ScalaTest's <a href="@latestScaladoc/#org.scalatest.selenium.HtmlUnit"><code>HtmlUnit</code></a> trait, like this:</p><p><pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">HtmlUnit</span> {
+<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">should.Matchers</span> <span class="stReserved">with</span> <span class="stType">HtmlUnit</span> {
 
   <span class="stReserved">val</span> host = <span class="stQuotedString">"http://localhost:9000/"</span>
 

--- a/app/views/userGuide/usingSelenium.scala.html
+++ b/app/views/userGuide/usingSelenium.scala.html
@@ -37,7 +37,7 @@ libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "@latestSel
 entirety except for one missing piece: an implicit <code>org.openqa.selenium.WebDriver</code>. One way to provide the missing
 implicit driver is to declare one as a member of your test class, like this:</p><p>
 <pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">WebBrowser</span> {
+<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">WebBrowser</span> {
 
   <span class="stReserved">implicit</span> <span class="stReserved">val</span> webDriver: <span class="stType">WebDriver</span> = <span class="stReserved">new</span> <span class="stType">HtmlUnitDriver</span>
 
@@ -52,7 +52,7 @@ implicit driver is to declare one as a member of your test class, like this:</p>
 driver provided by Selenium.
 Thus a simpler way to use the <code>HtmlUnit</code> driver, for example, is to extend
 ScalaTest's <a href="@latestScaladoc/#org.scalatest.selenium.HtmlUnit"><code>HtmlUnit</code></a> trait, like this:</p><p><pre class="stHighlighted">
-<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">HtmlUnit</span> {
+<span class="stReserved">class</span> <span class="stType">BlogSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> <span class="stReserved">with</span> <span class="stType">ShouldMatchers</span> <span class="stReserved">with</span> <span class="stType">HtmlUnit</span> {
 
   <span class="stReserved">val</span> host = <span class="stQuotedString">"http://localhost:9000/"</span>
 

--- a/app/views/userGuide/usingTheRunner.scala.html
+++ b/app/views/userGuide/usingTheRunner.scala.html
@@ -52,7 +52,7 @@ scala [-cp scalatest-&lt;version&gt;.jar:...] org.scalatest.tools.Runner [argume
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-b <em>&lt;TestNG XML file&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">run <a href="#specifyingTestNGXML">TestNG tests</a> using the specified TestNG XML file</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-b testng.xml</code></td></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-F <em>&lt;span scale factor&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">a factor by which to <a href="#scalingTimeSpans">scale time spans</a><br/>(Note: only one <code>-F</code> is allowed)</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-F 10</code> <em>or</em> <code>-F 2.5</code></td></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-T <em>&lt;sorting timeout&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">specifies a integer timeout (in seconds) for sorting the events of<br/>parallel runs back into sequential order</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-T 5</code></td></tr>
-<tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-y <em>&lt;chosen styles&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">specifies <a href="#specifyingChosenStyles">chosen styles</a> for your project</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-y org.scalatest.FlatSpec</code></td></tr>
+<tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-y <em>&lt;chosen styles&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">specifies <a href="#specifyingChosenStyles">chosen styles</a> for your project</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-y org.scalatest.flatspec.AnyFlatSpec</code></td></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-i <em>&lt;suite ID&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">specifies a <a href="#selectingSuitesAndTests">suite to run by ID</a> (Note: must follow <code>-s</code>, <br/>and is intended to be used primarily by tools such as IDEs.)</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-i com.company.project.FileSpec-file1.txt</code></td></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-t <em>&lt;test name&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="#selectingSuitesAndTests">select the test</a> with the specified name</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-t "An empty Stack should complain when popped"</code></td></tr>
 <tr><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-z <em>&lt;test name substring&gt;</em></code></td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="#selectingSuitesAndTests">select tests</a> whose names include the specified substring</td><td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><code>-z "popped"</code></td></tr>
@@ -359,26 +359,26 @@ it is best to minimize the styles used in any given project to a few, or one.</p
 specify the chosen styles in your project build. If chosen styles is defined, ScalaTest style traits that are
 not among the chosen list will abort with a message complaining that the style trait is not one of the
 chosen styles. The style name for each ScalaTest style trait is its fully qualified name. For example,
-to specify that <code>org.scalatest.FunSpec</code> as your chosen style you'd pass this to
+to specify that <code>org.scalatest.funspec.AnyFunSpec</code> as your chosen style you'd pass this to
 <code>Runner</code>:</p>
 
 <p><pre class="stExamples">
--y org.scalatest.FunSpec
+-y org.scalatest.funspec.AnyFunSpec
 </pre></p>
 
-<p>If you wanted <code>org.scalatest.FunSpec</code> as your main unit testing style, but also wanted to
-allow <code>PropSpec</code> for test matrixes and <code>FeatureSpec</code> for
+<p>If you wanted <code>org.scalatest.funspec.AnyFunSpec</code> as your main unit testing style, but also wanted to
+allow <code>AnyPropSpec</code> for test matrixes and <code>AnyFeatureSpec</code> for
 integration tests, you would write:</p>
 
 <p><pre class="stExamples">
--y org.scalatest.FunSpec -y org.scalatest.PropSpec -y org.scalatest.FeatureSpec
+-y org.scalatest.funspec.AnyFunSpec -y org.scalatest.propspec.AnyPropSpec -y org.scalatest.featurespec.AnyFeatureSpec
 </pre></p>
 
-<p>To select <code>org.scalatest.FlatSpec</code> as your main unit testing style, but allow
-<code>org.scalatest.fixture.FlatSpec</code> for multi-threaded unit tests, you'd write:</p>
+<p>To select <code>org.scalatest.flatspec.AnyFlatSpec</code> as your main unit testing style, but allow
+<code>org.scalatest.fixture.AnyFlatSpec</code> for multi-threaded unit tests, you'd write:</p>
 
 <p><pre class="stExamples">
--y org.scalatest.FlatSpec -y org.scalatest.fixture.FlatSpec
+-y org.scalatest.flatspec.AnyFlatSpec -y org.scalatest.fixture.AnyFlatSpec
 </pre></p>
 
 <p>The style name for a suite is obtained by invoking its <code>styleName</code> method. Custom style

--- a/app/views/userGuide/usingTheScalatestShell.scala.html
+++ b/app/views/userGuide/usingTheScalatestShell.scala.html
@@ -79,7 +79,7 @@ names, for example:
 </p>
 
 <pre style="background-color: #2c415c; padding: 10px">
-<span style="color: white">scala> class ArithmeticSuite extends AnyFunSuite with matchers.ShouldMatchers {
+<span style="color: white">scala> class ArithmeticSuite extends AnyFunSuite with matchers.should.Matchers {
      |   test("addition works") { 
      |     1 + 1 should equal (2)
      |   } 

--- a/app/views/userGuide/usingTheScalatestShell.scala.html
+++ b/app/views/userGuide/usingTheScalatestShell.scala.html
@@ -79,7 +79,7 @@ names, for example:
 </p>
 
 <pre style="background-color: #2c415c; padding: 10px">
-<span style="color: white">scala> class ArithmeticSuite extends FunSuite with matchers.ShouldMatchers {
+<span style="color: white">scala> class ArithmeticSuite extends AnyFunSuite with matchers.ShouldMatchers {
      |   test("addition works") { 
      |     1 + 1 should equal (2)
      |   } 
@@ -201,10 +201,10 @@ To enable short stack traces during a single run, use <code>shortstacks</code>:
   at line2$object$$iw$$iw$$iw$$iw$ArithmeticSuite$$anonfun$3.apply$mcV$sp(<console>:16)
   at line2$object$$iw$$iw$$iw$$iw$ArithmeticSuite$$anonfun$3.apply(<console>:16)
   at line2$object$$iw$$iw$$iw$$iw$ArithmeticSuite$$anonfun$3.apply(<console>:16)
-  at org.scalatest.FunSuite$$anon$1.apply(FunSuite.scala:992)
+  at org.scalatest.funsuite.AnyFunSuite$$anon$1.apply(AnyFunSuite.scala:992)
   at org.scalatest.Suite$class.withFixture(Suite.scala:1661)
   at line2$object$$iw$$iw$$iw$$iw$ArithmeticSuite.withFixture(<console>:8)
-  at org.scalatest.FunSuite$class.invokeWithFixture$1(FunSuite.scala:989)
+  at org.scalatest.funsuite.AnyFunSuite$class.invokeWithFixture$1(AnyFunSuite.scala:989)
   ...</span>
 <span style="color: #cfc923">- division works (pending)</span>
 </pre>

--- a/app/views/userGuide/writingYourFirstTest.scala.html
+++ b/app/views/userGuide/writingYourFirstTest.scala.html
@@ -24,19 +24,19 @@
 <h1>Writing your first test</h1>
 
 <p>
-1. In ScalaTest, you define tests inside classes that extend a <em>style class</em> such as <a href="@latestScaladoc/#org.scalatest.FlatSpec"><code>FlatSpec</code></a>
+1. In ScalaTest, you define tests inside classes that extend a <em>style class</em> such as <a href="@latestScaladoc/#org.scalatest.flatspec.AnyFlatSpec"><code>AnyFlatSpec</code></a>
 (though in practice you'd usually directly extend a <a href="defining_base_classes">base class defined for your project</a>, which extends a ScalaTest style class):
 </p>
 
 <pre class="stHighlighted">
-<span class="stReserved">import</span> org.scalatest.FlatSpec
-<br /><span class="stReserved">class</span> <span class="stType">FirstSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<span class="stReserved">import</span> org.scalatest.flatspec.AnyFlatSpec
+<br /><span class="stReserved">class</span> <span class="stType">FirstSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
   // tests go here...
 }
 </pre>
 
 <p>
-2. Each test in a <code>FlatSpec</code> is composed of a sentence that specifies a bit of required behavior and a block of code that tests it.
+2. Each test in a <code>AnyFlatSpec</code> is composed of a sentence that specifies a bit of required behavior and a block of code that tests it.
 The sentence needs a subject, such as <code>"A Stack"</code>; a verb, either <code>should</code>, <code>must</code>, or <code>can</code>; and 
 the rest of the sentence. Here's an example:
 </p>
@@ -60,7 +60,7 @@ After the sentence you put the word <code>in</code> followed by the body of the 
 <pre class="stHighlighted">
 <span class="stReserved">import</span> collection.mutable.Stack
 <span class="stReserved">import</span> org.scalatest._
-<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">FlatSpec</span> {
+<br /><span class="stReserved">class</span> <span class="stType">StackSpec</span> <span class="stReserved">extends</span> <span class="stType">AnyFlatSpec</span> {
 <br />  <span class="stQuotedString">&quot;A Stack&quot;</span> should <span class="stQuotedString">&quot;pop values in last-in-first-out order&quot;</span> in {
     <span class="stReserved">val</span> stack = <span class="stReserved">new</span> <span class="stType">Stack[Int]</span>
     stack.push(<span class="stLiteral">1</span>)


### PR DESCRIPTION
This PR updates the User Guide as follows:

  *  All style traits have been renamed to their `Any*` counterparts
  *  `ShouldMatchers` and `MustMatchers` references have been changed to `should.Matchers` and `must.Matchers`, respectively.

https://github.com/scalatest/scalatest/issues/1835