### PR TITLE
Secret Key for Play 2.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file(".")).settings(
   name := "scalatest-website",
-  version := "scalatest-220506-ecr",
+  version := "scalatest-220621b-ecr",
   scalaVersion := "2.13.8",
   libraryDependencies ++= Seq(
     "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,7 +5,7 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret=${APP_SECRET}
+play.http.secret.key=${APP_SECRET}
 
 # The application languages
 # ~~~~~


### PR DESCRIPTION
Changed to use play.http.secret.key for secret key.