### PR TITLE
Fix ScalaTest Maven Plugin Page's Version

### DIFF
--- a/app/views/userGuide/usingTheScalatestMavenPlugin.scala.html
+++ b/app/views/userGuide/usingTheScalatestMavenPlugin.scala.html
@@ -27,7 +27,7 @@ and access all functionality of the ScalaTest <code>Runner</code>, including par
 <ul>
 <li>group id: org.scalatest</li>
 <li>artifact id: scalatest-maven-plugin</li>
-<li>version: 1.0</li>
+<li>version: 2.0.2</li>
 </ul>
 
 <p>
@@ -49,7 +49,7 @@ Here's an example of how to do this in your pom.xml:
 &lt;plugin&gt;
   &lt;groupId&gt;org.scalatest&lt;/groupId&gt;
   &lt;artifactId&gt;scalatest-maven-plugin&lt;/artifactId&gt;
-  &lt;version&gt;1.0&lt;/version&gt;
+  &lt;version&gt;2.0.2&lt;/version&gt;
   &lt;configuration&gt;
     &lt;reportsDirectory&gt;${project.build.directory}/surefire-reports&lt;/reportsDirectory&gt;
     &lt;junitxml&gt;.&lt;/junitxml&gt;


### PR DESCRIPTION
Updated scalatest-maven-plugin version to 2.0.2 in Maven Plugin user guide page.