### PR TITLE
ScalaTest+ Module Versions Update

### DIFF
--- a/app/views/plus/easymockVersions.scala.html
+++ b/app/views/plus/easymockVersions.scala.html
@@ -32,6 +32,12 @@ Click on the <em>ScalaTest + EasyMock</em> to visit the Scaladoc for that releas
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + EasyMock Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">EasyMock Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-easymock-4.3/3.2.13.0/org/scalatestplus/easymock/EasyMockSugar.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.3</td>
+</tr>
+
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-easymock-4.3/3.2.12.0/org/scalatestplus/easymock/EasyMockSugar.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.3</td>

--- a/app/views/plus/jmockVersions.scala.html
+++ b/app/views/plus/jmockVersions.scala.html
@@ -32,6 +32,12 @@ Click on the <em>ScalaTest + JMock</em> to visit the Scaladoc for that release.
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + JMock Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">JMock Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-jmock-2.12/3.2.13.0/org/scalatestplus/jmock/JMockCycle.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.12.x</td>
+</tr>
+
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-jmock-2.12/3.2.12.0/org/scalatestplus/jmock/JMockCycle.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">2.12.x</td>

--- a/app/views/plus/junitVersions.scala.html
+++ b/app/views/plus/junitVersions.scala.html
@@ -32,6 +32,12 @@ Click on the <em>ScalaTest + JUnit</em> to visit the Scaladoc for that release.
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + JUnit Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">JUnit Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-junit-4.13/3.2.13.0/org/scalatestplus/junit/AssertionsForJUnit.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.13</td>
+</tr>
+
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-junit-4.13/3.2.12.0/org/scalatestplus/junit/AssertionsForJUnit.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.13</td>

--- a/app/views/plus/mockitoVersions.scala.html
+++ b/app/views/plus/mockitoVersions.scala.html
@@ -32,6 +32,12 @@ Click on the <em>ScalaTest + Mockito</em> to visit the Scaladoc for that release
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + Mockito Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">Mockito Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-mockito-4.6/3.2.13.0/org/scalatestplus/mockito/MockitoSugar.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.6</td>
+</tr>
+
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-mockito-4.5/3.2.12.0/org/scalatestplus/mockito/MockitoSugar.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.5</td>

--- a/app/views/plus/scalacheckVersions.scala.html
+++ b/app/views/plus/scalacheckVersions.scala.html
@@ -32,6 +32,11 @@ Click on the <em>ScalaTest + ScalaCheck</em> to visit the Scaladoc for that rele
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + ScalaCheck Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaCheck Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-scalacheck-1.16/3.2.13.0/org/scalatestplus/scalacheck/ScalaCheckPropertyChecks.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">1.16.x</td>
+</tr>
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-scalacheck-1.16/3.2.12.0/org/scalatestplus/scalacheck/ScalaCheckPropertyChecks.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">1.16.x</td>

--- a/app/views/plus/seleniumVersions.scala.html
+++ b/app/views/plus/seleniumVersions.scala.html
@@ -32,7 +32,13 @@ Click on the <em>ScalaTest + Selenium</em> to visit the Scaladoc for that releas
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + Selenium Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">Selenium Versions</th></tr>
 
 <tr>
-<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-selenium-4.1/3.2.12.0/org/scalatestplus/selenium/WebBrowser.html")">3.2.12.1</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-selenium-4.2/3.2.13.0/org/scalatestplus/selenium/WebBrowser.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.2</td>
+</tr>
+
+<tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-selenium-4.1/3.2.12.1/org/scalatestplus/selenium/WebBrowser.html")">3.2.12.1</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">4.1</td>
 </tr>

--- a/app/views/plus/testngVersions.scala.html
+++ b/app/views/plus/testngVersions.scala.html
@@ -32,6 +32,12 @@ Click on the <em>ScalaTest + TestNG</em> to visit the Scaladoc for that release.
 <tr><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest + TestNG Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">ScalaTest Version</th><th style="background-color: #CCCCCC; border-width: 1px; padding: 10px; text-align: center; border: 1px solid black">TestNG Versions</th></tr>
 
 <tr>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-testng-7.5/3.2.13.0/org/scalatestplus/testng/TestNGSuite.html")">3.2.13.0</a></td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.13</td>
+<td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">7.5</td>
+</tr>
+
+<tr>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center"><a href="@routes.Assets.at("/public/scaladoc", "plus-testng-7.5/3.2.12.0/org/scalatestplus/testng/TestNGSuite.html")">3.2.12.0</a></td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">3.2.12</td>
 <td style="border-width: 1px; padding: 3px; border: 1px solid black; text-align: center">7.5</td>


### PR DESCRIPTION
Updated 3.2.13.0 to all versions page of scalatest+ modules.