### PR TITLE
Using Matchers Page Update

### DIFF
--- a/app/views/userGuide/usingMatchers.scala.html
+++ b/app/views/userGuide/usingMatchers.scala.html
@@ -801,8 +801,8 @@ in List(1, 2, 3, 4, 5)
         at ...
 </pre>
 
-<p>Note: in the current 2.0.M6-SNAP release, the type of object used with inspector shorthands must be <code>GenTraversable</code>, but this will likely be widened to
-include Java collections, arrays, iterators, etc., for 2.0.M6.</p>
+<p>Note: in the current release, the type of object used with inspector shorthands must be <code>GenTraversable</code>, but this will likely be widened to
+include Java collections and iterators for future release.</p>
 
 <a name="singleElementCollections"> </a>
 <h2> Single-element collections </h2>


### PR DESCRIPTION
Updated using matchers page to not include reference to 2.0-M6, and removed array from future support list.