### PR TITLE
Property Testing User Guide Page Version Fix

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -159,7 +159,7 @@ object Application {
   val latestJUnit5Version = "5-10"
   val latestMockitoVersion = "5-10"
   val latestScalaCheckVersion = "1-17"
-  val latestScalaCheckPlusVersion = "3.2.17.0"
+  val latestScalaCheckPlusVersion = "3.2.18.0"
   val latestTestNGVersion = "7-5"  
   val quickStartXmlJar = "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_3/2.1.0/scala-xml_3-2.1.0.jar"
   val latestPlusScalaCheckDoc = "plus-scalacheck-1.17/3.2.18.0"

--- a/app/views/userGuide/propertyBasedTesting.scala.html
+++ b/app/views/userGuide/propertyBasedTesting.scala.html
@@ -52,7 +52,7 @@ in your SBT file, or if you use Maven:
 <pre class="stGrayback">
 &lt;dependency&gt;
     &lt;groupId&gt;org.scalatestplus&lt;/groupId&gt;
-    &lt;artifactId&gt;scalacheck-@{latestScalaCheckVersion}_2.13&lt;/artifactId&gt;
+    &lt;artifactId&gt;scalacheck-@{latestScalaCheckVersion}_3&lt;/artifactId&gt;
     &lt;version&gt;@latestScalaCheckPlusVersion&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;    

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file(".")).settings(
   name := "scalatest-website",
-  version := "240508",
+  version := "240613",
   scalaVersion := "3.3.1",
   libraryDependencies ++= Seq(
     guice,


### PR DESCRIPTION
Fixed version number of scalatest+scalacheck to 3.2.18.0, and use scala 3 artifacts for maven dependency example.