### PR TITLE
GitHub Sponsor

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -65,11 +65,13 @@ class Application @Inject() (cc: ControllerComponents) extends AbstractControlle
   }
 
   def donate = Action {
-    Ok(views.html.donate())
+    //Ok(views.html.donate())
+    Redirect("https://github.com/sponsors/scalatest", TEMPORARY_REDIRECT)
   }
 
   def sponsor = Action {
-    Ok(views.html.sponsor())
+    //Ok(views.html.sponsor())
+    Redirect("https://github.com/sponsors/scalatest", TEMPORARY_REDIRECT)
   }
 
 /*

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -40,7 +40,7 @@
 
 <!-- Top of scalatest.org 660 x 60 [async] -->
 
-<script id="adsArtimaScript" type="text/javascript" src="https://www.artima.com/assets/javascripts/4ca150665e51d0b1c3890ca1b891c507-ads.js?product=ScalaTest"></script>
+<script id="adsArtimaScript" type="text/javascript" src="https://www.artima.com/assets/javascripts/3cbad67e7fa9539151489fd25cf64fdd-ads.js?product=ScalaTest"></script>
 
     <div id="Header">
 


### PR DESCRIPTION
- Changed to use the new ads.js which includes the new ads for ScalaTest GitHub sponsor link.
- Redirect donate and sponsor link to github sponsor page.