### PR TITLE
Versions Upgrade with CVE Patch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 lazy val root = (project in file(".")).settings(
   name := "scalatest-website",
   version := "260414",
-  scalaVersion := "3.3.4",
+  scalaVersion := "3.3.8",
   libraryDependencies ++= Seq(
     guice,
     "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
@@ -13,7 +13,7 @@ lazy val root = (project in file(".")).settings(
   Docker / maintainer := "Artima Inc.", 
   dockerExposedPorts ++= Seq(9000), 
   dockerUpdateLatest := true,
-  dockerBaseImage := "eclipse-temurin:17",
+  dockerBaseImage := "eclipse-temurin:25",
   Universal / javaOptions ++= Seq(
     // -J params will be added as jvm parameters
     "-J-Xmx128m",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@
 logLevel := Level.Warn
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.11")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")


### PR DESCRIPTION
Updated Scala version to 3.3.8, Play Framework 3.0.11 and JDK 25.  Note that upgrading to Play Framework 3.0.11 also patch an important CVE https://github.com/playframework/playframework/issues/13681 .